### PR TITLE
Call the appropriate txn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
 	ICONNAME   = nanos_app_helium.gif
 endif
 
-APPVERSION = 2.2.0
+APPVERSION = 2.2.1
 
 # The --path argument here restricts which BIP32 paths the app is allowed to derive.
 ifeq ($(TESTNET),true)

--- a/src/ux/nanos/nanos_burn_txn.c
+++ b/src/ux/nanos/nanos_burn_txn.c
@@ -43,7 +43,7 @@ static unsigned int ui_signTxn_approve_button(unsigned int button_mask, unsigned
 
 	case BUTTON_RIGHT:
 	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		adpu_tx = create_helium_pay_txn(CTX.account_index);
+		adpu_tx = create_helium_burn_txn(CTX.account_index);
 		io_exchange_with_code(SW_OK, adpu_tx);
 		ui_idle();
 		break;


### PR DESCRIPTION
The Nano S burn transaction calls the `pay_txn` instead of `burn_txn`