### PR TITLE
do not encode a zero memo

### DIFF
--- a/src/txns/payment_v2.c
+++ b/src/txns/payment_v2.c
@@ -36,9 +36,10 @@ uint32_t create_helium_pay_txn(uint8_t account){
     pb_encode_tag(&ostream, PB_WT_VARINT, helium_payment_amount_tag);
     pb_encode_varint(&ostream, ctx->amount);
 
-    pb_encode_tag(&ostream, PB_WT_VARINT, helium_payment_memo_tag);
-    pb_encode_varint(&ostream, ctx->memo);
-
+    if(ctx->memo) {
+        pb_encode_tag(&ostream, PB_WT_VARINT, helium_payment_memo_tag);
+        pb_encode_varint(&ostream, ctx->memo);
+    }
     len_payments = ostream.bytes_written;
 
     // now do the top-level message


### PR DESCRIPTION
In protobuf encoding, a mandatory field assigned the default value is typically skipped and its value is implied to be the default. Previously, we encoded the value no matter what, which gets properly decoded but makes the signature invalid when the memo is 0 as the the typical serialization/encoding of the transaction used for signature verification will omit the 0 field. In other words, payment_v2 with 0 memo would previously fail signature check.