### PR TITLE
Nano S matches X/S+ confirm UX. All UX provide wallet for txn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
 	ICONNAME   = nanox_app_helium.gif
 endif
 
-APPVERSION = 2.2.4
+APPVERSION = 2.3.0
 
 # The --path argument here restricts which BIP32 paths the app is allowed to derive.
 ifeq ($(TESTNET),true)
@@ -49,7 +49,6 @@ APP_LOAD_PARAMS = --appFlags 0x240 --path "44'/905'" --curve secp256k1 --curve e
 else
 APP_LOAD_PARAMS = --appFlags 0x240 --path "44'/904'" --curve secp256k1 --curve ed25519 $(COMMON_LOAD_PARAMS)
 endif
-
 
 APP_SOURCE_PATH = src
 SDK_SOURCE_PATH = lib_stusb lib_stusb_impl

--- a/src/get_version.c
+++ b/src/get_version.c
@@ -12,5 +12,10 @@ void handle_get_version(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t da
     G_io_apdu_buffer[0] = APPVERSION[0] - '0';
 	G_io_apdu_buffer[1] = APPVERSION[2] - '0';
 	G_io_apdu_buffer[2] = APPVERSION[4] - '0';
-	io_exchange_with_code(SW_OK, 3);
+#ifdef HELIUM_TESTNET
+    G_io_apdu_buffer[3] = 'T';
+#else
+    G_io_apdu_buffer[3] = 'M';
+#endif
+    io_exchange_with_code(SW_OK, 4);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -25,7 +25,8 @@
 #include "txns/helium.h"
 #include "ux/helium_ux.h"
 
-commandContext global;
+globalContext_t global;
+commandContext_t cmd;
 
 // io_exchange_with_code is a helper function for sending response APDUs from
 // button handlers. Note that the IO_RETURN_AFTER_TX flag is set. 'tx' is the
@@ -67,7 +68,8 @@ handler_fn_t handle_sign_transfer_sec_txn;
 
 
 static handler_fn_t* lookupHandler(uint8_t ins) {
-	switch (ins) {
+    global.lock = false;
+    switch (ins) {
 	case INS_GET_VERSION:    return handle_get_version;
 	case INS_GET_PUBLIC_KEY: return handle_get_public_key;
 	case INS_SIGN_PAYMENT_TXN:   return handle_sign_payment_txn;

--- a/src/save_context.c
+++ b/src/save_context.c
@@ -10,11 +10,12 @@ static inline uint32_t U4LE(const uint8_t *buf, size_t off) {
 #define U8LE(buf, off) (((uint64_t)(U4LE(buf, off + 4)) << 32) | ((uint64_t)(U4LE(buf, off))     & 0xFFFFFFFF))
 
 bool save_payment_context(uint8_t p1, __attribute__((unused)) uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, paymentContext_t *ctx) {
+    global.lock = false;
     if (dataLength >= 24 + SIZEOF_B58_KEY + 8) {
         ctx->amount = U8LE(dataBuffer, 0);
         ctx->fee = U8LE(dataBuffer, 8);
         ctx->nonce = U8LE(dataBuffer, 16);
-        ctx->account_index = p1;
+        global.account_index = p1;
         memmove(ctx->payee, &dataBuffer[24], sizeof(ctx->payee));
         ctx->memo = U8LE(dataBuffer, 24+SIZEOF_B58_KEY);
         return true;
@@ -24,10 +25,11 @@ bool save_payment_context(uint8_t p1, __attribute__((unused)) uint8_t p2, uint8_
 }
 
 bool save_stake_validator_context(uint8_t p1, __attribute__((unused)) uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, stakeValidatorContext_t *ctx) {
+    global.lock = false;
     if (dataLength >= 16 + sizeof(ctx->address)) {
         ctx->stake = U8LE(dataBuffer, 0);
         ctx->fee  = U8LE(dataBuffer, 8);
-        ctx->account_index = p1;
+        global.account_index = p1;
         memmove(ctx->address, &dataBuffer[16], sizeof(ctx->address));
         return true;
     } else {
@@ -36,11 +38,12 @@ bool save_stake_validator_context(uint8_t p1, __attribute__((unused)) uint8_t p2
 }
 
 bool save_transfer_validator_context(uint8_t p1, __attribute__((unused)) uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, transferValidatorContext_t *ctx) {
+    global.lock = false;
     if (dataLength >= 24+3*SIZEOF_B58_KEY + sizeof(ctx->old_address)) {
         ctx->stake_amount = U8LE(dataBuffer, 0);
         ctx->payment_amount  = U8LE(dataBuffer, 8);
         ctx->fee = U8LE(dataBuffer, 16);
-        ctx->account_index = p1;
+        global.account_index = p1;
         memmove(ctx->new_owner, &dataBuffer[24], sizeof(ctx->new_owner));
         memmove(ctx->old_owner, &dataBuffer[24+SIZEOF_B58_KEY], sizeof(ctx->old_owner));
         memmove(ctx->new_address, &dataBuffer[24+2*SIZEOF_B58_KEY], sizeof(ctx->new_address));
@@ -52,11 +55,12 @@ bool save_transfer_validator_context(uint8_t p1, __attribute__((unused)) uint8_t
 }
 
 bool save_unstake_validator_context(uint8_t p1, __attribute__((unused)) uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, unstakeValidatorContext_t *ctx) {
+    global.lock = false;
     if (dataLength >= 24 + sizeof(ctx->address)) {
         ctx->stake_amount = U8LE(dataBuffer, 0);
         ctx->stake_release_height = U8LE(dataBuffer, 8);
         ctx->fee  = U8LE(dataBuffer, 16);
-        ctx->account_index = p1;
+        global.account_index = p1;
         memmove(ctx->address, &dataBuffer[24], sizeof(ctx->address));
         return true;
     } else {
@@ -65,12 +69,13 @@ bool save_unstake_validator_context(uint8_t p1, __attribute__((unused)) uint8_t 
 }
 
 bool save_burn_context(uint8_t p1, __attribute__((unused)) uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, burnContext_t *ctx) {
+    global.lock = false;
     if (dataLength >= 32 + sizeof(ctx->payee)) {
         ctx->amount = U8LE(dataBuffer, 0);
         ctx->fee = U8LE(dataBuffer, 8);
         ctx->nonce = U8LE(dataBuffer, 16);
         ctx->memo = U8LE(dataBuffer, 24);
-        ctx->account_index = p1;
+        global.account_index = p1;
         memmove(ctx->payee, &dataBuffer[32], sizeof(ctx->payee));
         return true;
     } else {
@@ -79,11 +84,12 @@ bool save_burn_context(uint8_t p1, __attribute__((unused)) uint8_t p2, uint8_t *
 }
 
 bool save_transfer_sec_context(uint8_t p1, __attribute__((unused)) uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, transferSecContext_t *ctx) {
+    global.lock = false;
     if (dataLength >= 24 + sizeof(ctx->payee)) {
         ctx->amount = U8LE(dataBuffer, 0);
         ctx->fee = U8LE(dataBuffer, 8);
         ctx->nonce = U8LE(dataBuffer, 16);
-        ctx->account_index = p1;
+        global.account_index = p1;
         memmove(ctx->payee, &dataBuffer[24], sizeof(ctx->payee));
         return true;
     } else {

--- a/src/save_context.h
+++ b/src/save_context.h
@@ -2,41 +2,31 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "nanos_paging.h"
 
 #define SIZEOF_B58_KEY 34
 
-typedef struct {
-    uint8_t displayIndex;
-    uint8_t fullStr[55]; // variable length
-    // partialStr contains 12 characters of a longer string. This allows text
-    // to be scrolled.
-    uint8_t partialStr[13];
-    uint8_t fullStr_len;
-} getPublicKeyContext_t;
 
 typedef struct {
     uint8_t displayIndex;
-    uint8_t fullStr[55]; // variable length
-    // partialStr contains 12 characters of a longer string. This allows text
-    // to be scrolled.
-    uint8_t partialStr[13];
+    uint8_t fullStr[HELIUM_UX_MAX_CHARS+1];
+    uint8_t partialStr[CHARS_PER_PAGE+1];
     uint8_t fullStr_len;
     uint8_t account_index;
+    uint8_t title[HELIUM_UX_MAX_TITLE+1];
+    uint8_t title_len;
+    bool lock;
+} globalContext_t;
+
+typedef struct {
     uint64_t amount;
     uint64_t nonce;
     uint64_t fee;
-    unsigned char payee[34];
+    unsigned char payee[SIZEOF_B58_KEY];
     uint64_t memo;
 } paymentContext_t;
 
 typedef struct {
-    uint8_t displayIndex;
-    uint8_t fullStr[55]; // variable length
-    // partialStr contains 12 characters of a longer string. This allows text
-    // to be scrolled.
-    uint8_t partialStr[13];
-    uint8_t fullStr_len;
-    uint8_t account_index;
     uint64_t stake;
     uint64_t nonce;
     uint64_t fee;
@@ -44,13 +34,6 @@ typedef struct {
 } stakeValidatorContext_t;
 
 typedef struct {
-    uint8_t displayIndex;
-    uint8_t fullStr[55]; // variable length
-    // partialStr contains 12 characters of a longer string. This allows text
-    // to be scrolled.
-    uint8_t partialStr[13];
-    uint8_t fullStr_len;
-    uint8_t account_index;
     uint64_t stake_amount;
     uint64_t stake_release_height;
     uint64_t nonce;
@@ -59,13 +42,6 @@ typedef struct {
 } unstakeValidatorContext_t;
 
 typedef struct {
-    uint8_t displayIndex;
-    uint8_t fullStr[55]; // variable length
-    // partialStr contains 12 characters of a longer string. This allows text
-    // to be scrolled.
-    uint8_t partialStr[13];
-    uint8_t fullStr_len;
-    uint8_t account_index;
     uint64_t stake_amount;
     uint64_t payment_amount;
     uint64_t fee;
@@ -76,32 +52,18 @@ typedef struct {
 } transferValidatorContext_t;
 
 typedef struct {
-    uint8_t displayIndex;
-    uint8_t fullStr[55]; // variable length
-    // partialStr contains 12 characters of a longer string. This allows text
-    // to be scrolled.
-    uint8_t partialStr[13];
-    uint8_t fullStr_len;
-    uint8_t account_index;
     uint64_t amount;
     uint64_t nonce;
     uint64_t fee;
     uint64_t memo;
-    unsigned char payee[34];
+    unsigned char payee[SIZEOF_B58_KEY];
 } burnContext_t;
 
 typedef struct {
-    uint8_t displayIndex;
-    uint8_t fullStr[55]; // variable length
-    // partialStr contains 12 characters of a longer string. This allows text
-    // to be scrolled.
-    uint8_t partialStr[13];
-    uint8_t fullStr_len;
-    uint8_t account_index;
     uint64_t amount;
     uint64_t nonce;
     uint64_t fee;
-    unsigned char payee[34];
+    unsigned char payee[SIZEOF_B58_KEY];
 } transferSecContext_t;
 
 
@@ -116,13 +78,13 @@ bool save_transfer_sec_context(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint
 // life of the command. A separate context_t struct should be defined for each
 // command.
 typedef union {
-    getPublicKeyContext_t getPublicKeyContext;
     paymentContext_t paymentContext;
     stakeValidatorContext_t stakeValidatorContext;
     transferValidatorContext_t transferValidatorContext;
     unstakeValidatorContext_t unstakeValidatorContext;
     burnContext_t burnContext;
     transferSecContext_t transferSecContext;
-} commandContext;
+} commandContext_t;
 
-extern commandContext global;
+extern globalContext_t global;
+extern commandContext_t cmd;

--- a/src/txns/helium.c
+++ b/src/txns/helium.c
@@ -2,59 +2,58 @@
 #include "helium.h"
 
 uint32_t pretty_print_hnt(uint8_t *dst, uint64_t n){
-	if(n==0) {
-		dst[0] ='0';
-		dst[1] ='\0';
-		return 2;
-	}
+    if(n==0) {
+        dst[0] ='0';
+        dst[1] ='\0';
+        return 2;
+    }
 
-	uint32_t len = bin2dec(dst, n);
-	// this will be used to drop useless 0s
-	bool nonzero = false;
-	uint32_t written = 0;
+    uint32_t len = bin2dec(dst, n);
+    // this will be used to drop useless 0s
+    bool nonzero = false;
+    uint32_t written = 0;
 
-	// insert decimal if we are dealing with >1 HNT
-	if(len > 8){
-		uint32_t i = len - 1;
-		// shift out all the values larger than 10^8
-		while( i >= (len-8) ) {
-			if(dst[i]!='0' || nonzero){
-				dst[i+1] = dst[i];
-				nonzero = true;
-				written++;
-			}
-			i--;
-		}
-		// add the decimal if there are non-zeros smaller than 10^8
-		if(nonzero){
-			dst[ i+1 ] = '.';
-			written++;
-		}
+    // insert decimal if we are dealing with <1 HNT
+    if(len > 8){
+        uint32_t i = len - 1;
+        // shift out all the values larger than 10^8
+        while( i >= (len-8) ) {
+            if(dst[i]!='0' || nonzero){
+                dst[i+1] = dst[i];
+                nonzero = true;
+                written++;
+            }
+            i--;
+        }
+        // add the decimal if there are non-zeros smaller than 10^8
+        if(nonzero){
+            dst[ i+1 ] = '.';
+            written++;
+        }
 
-		written += (len-9);
-	} 
-	// prepend zeros and add decimal to <1 HNT
-	else {
-		uint32_t i = 0;
-		while( i < len ){
-			if(dst[len-i-1]!='0' || nonzero){
-				dst[8-i] = dst[len-i-1];
-				nonzero = true;
-				written++;
-			}
-			i++;
-		}
-		while(i <= 8) {
-			dst[8-i] = '0';
-			i++;
-			written++;
-		}
-		dst[0] = '.';
-		written--;
-
-	}
-	dst[written+1] ='\0';
-	return written;
+        written += (len-9);
+    }
+        // prepend zeros and add decimal to >1 HNT
+    else {
+        uint32_t i = 0;
+        while( i < len ){
+            if(dst[len-i-1]!='0' || nonzero){
+                dst[8-i] = dst[len-i-1];
+                nonzero = true;
+                written++;
+            }
+            i++;
+        }
+        while(i <= 8) {
+            dst[8-i] = '0';
+            i++;
+            written++;
+        }
+        dst[0] = '.';
+        written--;
+    }
+    dst[++written] ='\0';
+    return written;
 }
 
 

--- a/src/txns/payment_v2.c
+++ b/src/txns/payment_v2.c
@@ -9,7 +9,7 @@
 #define MAX_PAYMENT_SIZE (SIZEOF_HELIUM_KEY+2*4+23)
 
 uint32_t create_helium_pay_txn(uint8_t account){
-    paymentContext_t * ctx = &global.paymentContext;
+    paymentContext_t * ctx = &cmd.paymentContext;
     pb_ostream_t ostream;
 
     unsigned char payer[SIZEOF_HELIUM_KEY];

--- a/src/txns/stake_validator_v1.c
+++ b/src/txns/stake_validator_v1.c
@@ -5,7 +5,7 @@
 #include "save_context.h"
 
 uint32_t create_helium_stake_txn(uint8_t account){
-    stakeValidatorContext_t * ctx = &global.stakeValidatorContext;
+    stakeValidatorContext_t * ctx = &cmd.stakeValidatorContext;
     pb_ostream_t ostream;
 
     unsigned char owner[SIZEOF_HELIUM_KEY];

--- a/src/txns/token_burn_v1.c
+++ b/src/txns/token_burn_v1.c
@@ -5,7 +5,7 @@
 #include "save_context.h"
 
 uint32_t create_helium_burn_txn(uint8_t account){
-    burnContext_t * ctx = &global.burnContext;
+    burnContext_t * ctx = &cmd.burnContext;
     pb_ostream_t ostream;
 
     unsigned char payer[SIZEOF_HELIUM_KEY];

--- a/src/txns/transfer_sec.c
+++ b/src/txns/transfer_sec.c
@@ -5,7 +5,7 @@
 #include "save_context.h"
 
 uint32_t create_helium_transfer_sec(uint8_t account){
-    transferSecContext_t * ctx = &global.transferSecContext;
+    transferSecContext_t * ctx = &cmd.transferSecContext;
     pb_ostream_t ostream;
 
     unsigned char payer[SIZEOF_HELIUM_KEY];

--- a/src/txns/transfer_validator_v1.c
+++ b/src/txns/transfer_validator_v1.c
@@ -5,7 +5,7 @@
 #include "save_context.h"
 
 uint32_t create_helium_transfer_validator_txn(uint8_t account){
-    transferValidatorContext_t * ctx = &global.transferValidatorContext;
+    transferValidatorContext_t * ctx = &cmd.transferValidatorContext;
     pb_ostream_t ostream;
 
     unsigned char owner[SIZEOF_HELIUM_KEY];

--- a/src/txns/unstake_validator_v1.c
+++ b/src/txns/unstake_validator_v1.c
@@ -5,7 +5,7 @@
 #include "save_context.h"
 
 uint32_t create_helium_unstake_txn(uint8_t account){
-    unstakeValidatorContext_t * ctx = &global.unstakeValidatorContext;
+    unstakeValidatorContext_t * ctx = &cmd.unstakeValidatorContext;
     pb_ostream_t ostream;
 
     unsigned char owner[SIZEOF_HELIUM_KEY];

--- a/src/ux/helium_ux.h
+++ b/src/ux/helium_ux.h
@@ -20,6 +20,8 @@ extern ux_state_t ux;
 #define UI_BACKGROUND() {{BAGL_RECTANGLE,0,0,0,128,32,0,0,BAGL_FILL,0,0xFFFFFF,0,0},NULL}
 #define UI_ICON_LEFT(userid, glyph) {{BAGL_ICON,userid,3,12,7,7,0,0,0,0xFFFFFF,0,0,glyph},NULL}
 #define UI_ICON_RIGHT(userid, glyph) {{BAGL_ICON,userid,117,13,8,6,0,0,0,0xFFFFFF,0,0,glyph},NULL}
+#define UI_ICON_CENTER(userid, glyph) {{BAGL_ICON,userid,60,18,8,6,0,0,0,0xFFFFFF,0,0,glyph},NULL}
+
 #define UI_TEXT(userid, x, y, w, text) {{BAGL_LABELINE,userid,x,y,w,12,0,0,0,0xFFFFFF,0,BAGL_FONT_OPEN_SANS_REGULAR_11px|BAGL_FONT_ALIGNMENT_CENTER,0},(char *)text}
 
 // ui_idle displays the main menu screen. Command handlers should call ui_idle

--- a/src/ux/nanos/nanos_burn_txn.c
+++ b/src/ux/nanos/nanos_burn_txn.c
@@ -12,45 +12,82 @@
 #include "save_context.h"
 #include "nanos_error.h"
 
-#define CTX global.burnContext
+#define CTX cmd.burnContext
+
+static void load_amount(page_cmd_t page_cmd);
+static void load_recipient(page_cmd_t page_cmd);
+static void load_payment_memo(page_cmd_t page_cmd);
+static void load_fee(page_cmd_t page_cmd);
+static void load_signature(page_cmd_t page_cmd);
+static void load_deny(page_cmd_t page_cmd);
+static void local_load_wallet(page_cmd_t page_cmd);
 
 static const bagl_element_t ui_signTxn_approve[] = {
 	UI_BACKGROUND(),
-	UI_ICON_LEFT(0x00, BAGL_GLYPH_ICON_CROSS),
-	UI_ICON_RIGHT(0x00, BAGL_GLYPH_ICON_CHECK),
-
-	UI_TEXT(0x00, 0, 18, 128, "Sign transaction?"),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CHECK),
+	UI_TEXT(0x00, 0, 12, 128, "Approve?"),
 };
 
-static const bagl_element_t* ui_prepro_signTxn_approve(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
 
-static unsigned int ui_signTxn_approve_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int adpu_tx;
+static const bagl_element_t ui_signTxn_deny[] = {
+	UI_BACKGROUND(),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CROSS),
+	UI_TEXT(0x00, 0, 12, 128, "Deny transaction?"),
+};
+
+static unsigned int ui_signTxn_deny_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		// make sure there's no data in the office
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_signature(LAST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_LEFT | BUTTON_EVT_FAST:
+        break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            local_load_wallet(FIRST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_FAST: // SEEK RIGHT
+        break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        // keeps the screen from flipping around after being denied
+        global.lock = true;
+        // make sure there's no data in the buffer
 		memset(G_io_apdu_buffer, 0, IO_APDU_BUFFER_SIZE);
 		// send a single 0 byte to differentiate from app not running
 		io_exchange_with_code(SW_OK, 1);
 		ui_idle();
 		break;
+	}
+	return 0;
+}
 
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		adpu_tx = create_helium_burn_txn(CTX.account_index);
+static unsigned int ui_signTxn_approve_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	int adpu_tx;
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_fee(LAST);
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_deny(LAST);
+        }
+		break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        global.lock = true;
+        adpu_tx = create_helium_burn_txn(global.account_index);
 		io_exchange_with_code(SW_OK, adpu_tx);
 		ui_idle();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
 		break;
 	}
 	return 0;
@@ -60,44 +97,28 @@ static const bagl_element_t ui_displayFee[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Data Credit Fee"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of fee
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayFee(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
 static unsigned int ui_displayFee_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_payment_memo,
+            &load_signature
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-		// display approval screen
-		UX_DISPLAY(ui_signTxn_approve, ui_prepro_signTxn_approve);
+    case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_payment_memo,
+            &load_signature
+        );
+        UX_REDISPLAY();
 		break;
 	}
 	return 0;
@@ -107,59 +128,30 @@ static const bagl_element_t ui_displayMemo[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Burn Memo"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of fee
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayMemo(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
 static unsigned int ui_displayMemo_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-    uint8_t len;
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_recipient,
+            &load_fee
+        );
+        UX_REDISPLAY();
+        break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_recipient,
+            &load_fee
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-        // display data credit transaction fee
-		len = bin2dec(CTX.fullStr, CTX.fee);
-		CTX.fullStr_len = len;
-		CTX.fullStr[len] = '\0';
-
-		uint8_t partlen = 12;
-		if(len < 12){
-			partlen = len;
-		}
-		memmove(CTX.partialStr, CTX.fullStr, partlen);
-		CTX.partialStr[partlen] = '\0';
-		CTX.displayIndex = 0;
-		// display fee
-		UX_DISPLAY(ui_displayFee, ui_prepro_displayFee);
-		break;
-	}
+    }
 	return 0;
 }
 
@@ -167,60 +159,30 @@ static const bagl_element_t ui_displayRecipient[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Recipient Address"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of the recipient
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayRecipient(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
 static unsigned int ui_displayRecipient_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	uint8_t len;
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_amount,
+            &load_payment_memo
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_amount,
+            &load_payment_memo
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-		// display burn memo
-		len = u64_to_base64(CTX.fullStr, CTX.memo);
-		CTX.fullStr_len = len;
-		CTX.fullStr[len] = '\0';
-
-		uint8_t partlen = 12;
-		if(len < 12){
-			partlen = len;
-		}
-		memmove(CTX.partialStr, CTX.fullStr, partlen);
-		CTX.partialStr[partlen] = '\0';
-		CTX.displayIndex = 0;
-
-		UX_DISPLAY(ui_displayMemo, ui_prepro_displayMemo);
-		break;
-	}
+    }
 	return 0;
 }
 
@@ -228,97 +190,167 @@ static const bagl_element_t ui_displayAmount[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-#ifdef HELIUM_TESTNET
-	UI_TEXT(0x00, 0, 12, 128, "Burn TNT"),
-#else
-	UI_TEXT(0x00, 0, 12, 128, "Burn HNT"),
-#endif
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of the amount
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayAmount(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
 static unsigned int ui_displayAmount_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	cx_sha256_t hash;
-	unsigned char hash_buffer[32];
-	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
-	uint8_t * address_with_check = G_io_apdu_buffer;
-
-	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
+    switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &local_load_wallet,
+            &load_recipient
+        );
+        UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &local_load_wallet,
+            &load_recipient
+        );
+        UX_REDISPLAY();
 		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-		for(uint8_t i=0; i<2; i++){
-			// display recipient address on screen
-			memmove(address_with_check, CTX.payee, 34);
-
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
-			memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-			size_t output_len;
-			btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-			CTX.fullStr[output_len] = '\0';
-			CTX.fullStr_len = output_len;
-			memmove(CTX.partialStr, CTX.fullStr, 12);
-			CTX.partialStr[12] = '\0';
-			CTX.displayIndex = 0;
-
-			UX_DISPLAY(ui_displayRecipient, ui_prepro_displayRecipient);
-		}
-
-		break;
-	}
+    }
 	return 0;
 }
 
-void handle_burn_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags,__attribute__((unused)) volatile unsigned int *tx) {
+static const bagl_element_t ui_getPublicKey[] = {
+	UI_BACKGROUND(),
+	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the public key or address.
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
+};
+
+// Define the button handler for the comparison screen. Again, this is nearly
+// identical to the signHash comparison button handler.
+static unsigned int ui_getPublicKey_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        if (!global.lock) {
+            change_page(
+                PREV,
+                &load_deny,
+                &load_amount
+            );
+        }
+		UX_REDISPLAY();
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        if (!global.lock) {
+            change_page(
+                NEXT,
+                &load_deny,
+                &load_amount
+            );
+        }
+		UX_REDISPLAY();
+		break;
+    }
+	return 0;
+}
+
+static void local_load_wallet(page_cmd_t page_cmd) {
+    load_wallet(page_cmd, load_deny, load_amount);
+    UX_DISPLAY(ui_getPublicKey, NULL);
+}
+
+void handle_burn_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength,
+                             volatile unsigned int *flags, __attribute__((unused)) volatile unsigned int *tx) {
 
     if(save_burn_context(p1, p2, dataBuffer, dataLength, &CTX)) {
-        // display amount on screen
-        uint8_t len = pretty_print_hnt(CTX.fullStr, CTX.amount);
-        uint8_t i = 0;
-        while(CTX.fullStr[i] != '\0' && i<12){
-            CTX.partialStr[i] = CTX.fullStr[i];
-            i++;
-        }
-        CTX.partialStr[i] = '\0';
-        CTX.fullStr_len = len;
-
-        CTX.displayIndex = 0;
-
-        UX_DISPLAY(ui_displayAmount, ui_prepro_displayAmount);
+        local_load_wallet(FIRST);
     } else {
         display_error();
     }
 	*flags |= IO_ASYNCH_REPLY;
+}
+
+static void load_fee(page_cmd_t page_cmd) {
+    uint8_t len = bin2dec(global.fullStr, CTX.fee);
+    global.title_len = sizeof("DC Fee (1/n)");
+    memcpy(global.title, &"DC Fee (1/n)", global.title_len);
+    global.fullStr_len = len;
+    global.fullStr[len] = '\0';
+    global.displayIndex = 0;
+    change_page(
+        page_cmd,
+        &load_payment_memo,
+        &load_signature
+    );
+    UX_DISPLAY(ui_displayFee, NULL);
+}
+
+static void load_recipient(page_cmd_t page_cmd) {
+	cx_sha256_t hash;
+	unsigned char hash_buffer[32];
+	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
+	uint8_t * address_with_check = G_io_apdu_buffer;
+    global.title_len = sizeof("Recipient (1/n)");
+    memcpy(global.title, &"Recipient (1/n)", global.title_len);
+    for(uint8_t i=0; i<2; i++){
+        memmove(address_with_check, CTX.payee, 34);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
+        memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
+        size_t output_len;
+        btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+        global.fullStr[output_len] = '\0';
+        global.fullStr_len = output_len;
+        change_page(
+            page_cmd,
+            &load_amount,
+            &load_payment_memo
+        );
+    }
+    UX_DISPLAY(ui_displayRecipient, NULL);
+}
+
+static void load_payment_memo(page_cmd_t page_cmd){
+    global.title_len = sizeof("Memo (1/n)");
+    memcpy(global.title, &"Memo (1/n)", global.title_len);
+    uint8_t len = u64_to_base64(global.fullStr, CTX.memo);
+    global.fullStr_len = len;
+    global.fullStr[len] = '\0';
+    change_page(
+        page_cmd,
+        &load_recipient,
+        &load_fee
+    );
+    UX_DISPLAY(ui_displayMemo, NULL);
+}
+
+static void load_amount(page_cmd_t page_cmd){
+    #ifdef HELIUM_TESTNET
+    global.title_len = sizeof("Burn TNT (1/n)");
+    memcpy(global.title, &"Burn TNT (1/n)", global.title_len);
+    #else
+    global.title_len = sizeof("Burn HNT (1/n)");
+    memcpy(global.title, &"Burn HNT (1/n)", global.title_len);
+    #endif
+    // display amount on screen
+    uint8_t len = pretty_print_hnt(global.fullStr, CTX.amount);
+    global.fullStr_len = len;
+    change_page(
+        page_cmd,
+        &load_signature,
+        &load_recipient
+    );
+    UX_DISPLAY(ui_displayAmount, NULL);
+}
+
+static void load_signature(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_approve, NULL);
+}
+
+static void load_deny(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_deny, NULL);
 }
 
 #endif

--- a/src/ux/nanos/nanos_get_public_key.c
+++ b/src/ux/nanos/nanos_get_public_key.c
@@ -10,8 +10,7 @@
 #include "helium.h"
 #include "helium_ux.h"
 
-// Get a pointer to getPublicKey's state variables.
-#define CTX global.getPublicKeyContext
+static uint16_t adpu_tx = 0;
 
 // Define the comparison screen. This is where the user will compare the
 // public key (or address) on their device to the one shown on the computer.
@@ -19,48 +18,41 @@ static const bagl_element_t ui_getPublicKey[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Confirm Address"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of the public key or address.
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-// Define the preprocessor for the comparison screen. As in signHash, this
-// preprocessor selectively hides the left/right arrows. The only difference
-// is that, since public keys and addresses have different lengths, checking
-// for the end of the string is slightly more complicated.
-static const bagl_element_t* ui_prepro_getPublicKey(const bagl_element_t *element) {
-	int fullSize =  CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
+static void local_load_wallet(page_cmd_t page_cmd);
 
 // Define the button handler for the comparison screen. Again, this is nearly
 // identical to the signHash comparison button handler.
 static unsigned int ui_getPublicKey_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
 	switch (button_mask) {
 	case BUTTON_LEFT:
 	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+        change_page(
+            PREV,
+            &local_load_wallet,
+            &local_load_wallet
+        );
+
 		UX_REDISPLAY();
 		break;
 
 	case BUTTON_RIGHT:
 	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+        change_page(
+            NEXT,
+            &local_load_wallet,
+            &local_load_wallet
+        );
 		UX_REDISPLAY();
 		break;
 
 	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
+        global.lock = true;
+        io_exchange_with_code(SW_OK, adpu_tx);
 		// The user has finished comparing, so return to the main screen.
 		ui_idle();
 		break;
@@ -68,20 +60,46 @@ static unsigned int ui_getPublicKey_button(unsigned int button_mask, __attribute
 	return 0;
 }
 
+static void local_load_wallet(page_cmd_t page_cmd) {
+    load_wallet(page_cmd, local_load_wallet, local_load_wallet);
+    UX_DISPLAY(ui_getPublicKey, NULL);
+}
+
 // handleGetPublicKey is the entry point for the getPublicKey command. It
 // reads the command parameters, prepares and displays the approval screen,
-// and 
+// and
 void handle_get_public_key(uint8_t p1, uint8_t p2,
                            __attribute__((unused)) uint8_t *dataBuffer,
                            __attribute__((unused)) uint16_t dataLength,
                            __attribute__((unused)) volatile unsigned int *flags,
                            __attribute__((unused)) volatile unsigned int *tx) {
-	size_t output_len;
-	// Sanity-check the command parameters.
+	// Sanity-check the command
 	if ((p1 != P1_PUBKEY_DISPLAY_ON) && (p1 != P1_PUBKEY_DISPLAY_OFF)) {
 		THROW(SW_INVALID_PARAM);
 	}
-	uint16_t adpu_tx = 2;
+    global.account_index = p2;
+
+    load_wallet(FIRST,
+        local_load_wallet,
+        local_load_wallet);
+
+	if (p1 == P1_PUBKEY_DISPLAY_ON) {
+        UX_DISPLAY(ui_getPublicKey, NULL);
+		// Sets the IO_ASYNC_REPLY, which allows the screen to load
+		*flags |= IO_ASYNCH_REPLY;
+	} else {
+        // Flush the APDU buffer, sending the response.
+        io_exchange_with_code(SW_OK, adpu_tx);
+    }
+}
+
+void load_wallet(page_cmd_t page_cmd,
+    void (*prev_menu)(page_cmd_t),
+    void (*next_menu)(page_cmd_t)) {
+	size_t output_len;
+    cx_sha256_t hash;
+	unsigned char hash_buffer[32];
+	adpu_tx = 2;
 
 	G_io_apdu_buffer[0] = 0; // prepend 0 byte to signify b58 format
 #ifdef HELIUM_TESTNET
@@ -89,12 +107,8 @@ void handle_get_public_key(uint8_t p1, uint8_t p2,
 #else
 	G_io_apdu_buffer[1] = NETTYPE_MAIN | KEYTYPE_ED25519;
 #endif
-	uint8_t account = p2;
-	get_pubkey_bytes(account, &G_io_apdu_buffer[adpu_tx]);
+	get_pubkey_bytes(global.account_index, &G_io_apdu_buffer[adpu_tx]);
 	adpu_tx += SIZE_OF_PUB_KEY_BIN;
-
-	cx_sha256_t hash;
-	unsigned char hash_buffer[32];
 
 	cx_sha256_init(&hash);
 	cx_hash(&hash.header, CX_LAST, G_io_apdu_buffer, adpu_tx, hash_buffer, 32);
@@ -104,28 +118,36 @@ void handle_get_public_key(uint8_t p1, uint8_t p2,
 	memmove(&G_io_apdu_buffer[adpu_tx], hash_buffer, SIZE_OF_SHA_CHECKSUM);
 	adpu_tx += SIZE_OF_SHA_CHECKSUM;
 
+    // for some reason this needs to be done twice to work
+    btchip_encode_base58(G_io_apdu_buffer, adpu_tx, global.fullStr, &output_len);
+    btchip_encode_base58(G_io_apdu_buffer, adpu_tx, global.fullStr, &output_len);
 
-	if (p1 == P1_PUBKEY_DISPLAY_ON) {
-		// for some reason this needs to run twice to get the display to work
-		// otherwise, first time running this command, key gets displayed blank
-		for(uint8_t i=0; i<2; i++){
-			btchip_encode_base58(G_io_apdu_buffer, adpu_tx, CTX.fullStr, &output_len);
-			CTX.fullStr[51] = '\0';
-			CTX.fullStr_len = output_len;
-			memmove(CTX.partialStr, CTX.fullStr, 12);
-			CTX.partialStr[12] = '\0';
-			CTX.displayIndex = 0;
+    global.fullStr[51] = '\0';
+    global.fullStr_len = output_len;
+    global.displayIndex = 0;
 
-			// Display the comparison screen.
-			UX_DISPLAY(ui_getPublicKey, ui_prepro_getPublicKey);
-		}
+    if (global.account_index < 10) {
+        global.title_len = sizeof("Wallet N (1/m)");
+        memcpy(global.title, &"Wallet N (1/m)", global.title_len);
+        global.title[7] = global.account_index + 48;
+    } else if (global.account_index < 100) {
+        global.title_len = sizeof("Wallet NN (1/m)");
+        memcpy(global.title, &"Wallet N (1/m)", global.title_len);
+        global.title[7] = global.account_index/10 + 48;
+        global.title[8] = global.account_index%10 + 48;
+    } else {
+        global.title_len = sizeof("Wallet NNN (1/m)");
+        memcpy(global.title, &"Wallet NNN (1/m)", global.title_len);
+        global.title[7] = global.account_index/100 + 48;
+        global.title[8] = global.account_index%100/10 + 48;
+        global.title[9] = global.account_index%10 + 48;
+    }
 
-		// Sets the IO_ASYNC_REPLY, which allows the screen to load
-		*flags |= IO_ASYNCH_REPLY;
-	}
-
-	// Flush the APDU buffer, sending the response.
-	io_exchange_with_code(SW_OK, adpu_tx);
+    change_page(
+        page_cmd,
+        prev_menu,
+        next_menu
+    );
 }
 
 #endif

--- a/src/ux/nanos/nanos_get_public_key.c
+++ b/src/ux/nanos/nanos_get_public_key.c
@@ -132,7 +132,7 @@ void load_wallet(page_cmd_t page_cmd,
         global.title[7] = global.account_index + 48;
     } else if (global.account_index < 100) {
         global.title_len = sizeof("Wallet NN (1/m)");
-        memcpy(global.title, &"Wallet N (1/m)", global.title_len);
+        memcpy(global.title, &"Wallet NN (1/m)", global.title_len);
         global.title[7] = global.account_index/10 + 48;
         global.title[8] = global.account_index%10 + 48;
     } else {

--- a/src/ux/nanos/nanos_paging.c
+++ b/src/ux/nanos/nanos_paging.c
@@ -1,0 +1,82 @@
+#include <stdint.h>
+#include <string.h>
+#include "nanos_paging.h"
+#include "save_context.h"
+
+void change_page(
+        page_cmd_t page_cmd,
+        void (*prev_menu)(page_cmd_t),
+        void (*next_menu)(page_cmd_t)) {
+    int page;
+    switch (page_cmd) {
+        case FIRST:
+            page = (global.fullStr_len/CHARS_PER_PAGE - ((global.fullStr_len%CHARS_PER_PAGE) ? 0 : 1));
+            global.title[global.title_len-3] = page + 1 + 48;
+            global.title[global.title_len-5] = '1';
+            if(page == 0) {
+                global.title[global.title_len-7] = '\0';
+            }
+            global.displayIndex = 0;
+            if (global.fullStr_len >= CHARS_PER_PAGE) {
+                memcpy(global.partialStr, &global.fullStr[global.displayIndex], CHARS_PER_PAGE);
+                (global.partialStr)[CHARS_PER_PAGE]='\0';
+            } else {
+                memcpy(global.partialStr, &global.fullStr[global.displayIndex], global.fullStr_len);
+                (global.partialStr)[global.fullStr_len]='\0';
+            }
+            break;
+        case LAST:
+            if (global.fullStr_len <= CHARS_PER_PAGE) {
+                change_page(
+                        FIRST,
+                        prev_menu,
+                        next_menu);
+            } else {
+                page = (global.fullStr_len / CHARS_PER_PAGE - ((global.fullStr_len % CHARS_PER_PAGE) ? 0 : 1));
+                global.displayIndex = page * CHARS_PER_PAGE;
+                global.title[global.title_len - 3] = page + 1 + 48;
+                global.title[global.title_len - 5] = page + 1 + 48;
+                int diff = global.fullStr_len - global.displayIndex;
+                memcpy(global.partialStr, &global.fullStr[global.displayIndex], diff);
+                global.partialStr[diff] = '\0';
+            }
+            break;
+        case PREV:
+            if (global.displayIndex == 0) {
+                if (prev_menu != 0){
+                    (*prev_menu)(LAST);
+                }
+            } else {
+                global.displayIndex -= CHARS_PER_PAGE;
+                page = (global.displayIndex/CHARS_PER_PAGE);
+                global.title[global.title_len-5] = page + 1 + 48;
+                memcpy(global.partialStr, &global.fullStr[global.displayIndex], CHARS_PER_PAGE);
+                global.partialStr[CHARS_PER_PAGE]='\0';
+            }
+            break;
+        case NEXT:
+            global.displayIndex += CHARS_PER_PAGE;
+            page = (global.displayIndex/CHARS_PER_PAGE);
+            global.title[global.title_len - 5] = page + 48;
+
+            uint8_t last_page = (global.fullStr_len / CHARS_PER_PAGE - ((global.fullStr_len % CHARS_PER_PAGE) ? 0 : 1));
+            global.title[global.title_len - 5] = last_page + 1 + 48;
+            if (page >last_page) {
+                if (next_menu != 0){
+                    (*next_menu)(FIRST);
+                }
+            } else {
+                global.title[global.title_len-5] = page + 1 + 48;
+
+                if (global.displayIndex + CHARS_PER_PAGE > global.fullStr_len) {
+                    int diff = global.fullStr_len - global.displayIndex;
+                    memcpy(global.partialStr, &global.fullStr[global.displayIndex], diff);
+                    global.partialStr[diff] = '\0';
+                } else {
+                    memcpy(global.partialStr, &global.fullStr[global.displayIndex], CHARS_PER_PAGE);
+                    global.partialStr[CHARS_PER_PAGE] = '\0';
+                }
+            }
+            break;
+    }
+}

--- a/src/ux/nanos/nanos_paging.h
+++ b/src/ux/nanos/nanos_paging.h
@@ -1,0 +1,27 @@
+#ifndef NANOS_PAGING_H
+#define NANOS_PAGING_H
+
+#define HELIUM_UX_MAX_CHARS 55
+#define HELIUM_UX_MAX_TITLE 20
+#define CHARS_PER_PAGE 12
+
+typedef enum {
+    FIRST,
+    NEXT,
+    PREV,
+    LAST
+} page_cmd_t;
+
+void change_page(
+        page_cmd_t page_cmd,
+        void (*prev_menu)(page_cmd_t),
+        void (*next_menu)(page_cmd_t)
+);
+
+void load_wallet(
+        page_cmd_t page_cmd,
+        void (*prev_menu)(page_cmd_t),
+        void (*next_menu)(page_cmd_t)
+);
+
+#endif

--- a/src/ux/nanos/nanos_payment_txn.c
+++ b/src/ux/nanos/nanos_payment_txn.c
@@ -11,46 +11,84 @@
 #include "helium_ux.h"
 #include "save_context.h"
 #include "nanos_error.h"
+#include "nanos_paging.h"
 
-#define CTX global.paymentContext
+#define CTX cmd.paymentContext
+
+static void load_amount(page_cmd_t page_cmd);
+static void load_recipient(page_cmd_t page_cmd);
+static void load_payment_memo(page_cmd_t page_cmd);
+static void load_fee(page_cmd_t page_cmd);
+static void load_signature(page_cmd_t page_cmd);
+static void load_deny(page_cmd_t page_cmd);
+static void local_load_wallet(page_cmd_t page_cmd);
 
 static const bagl_element_t ui_signTxn_approve[] = {
 	UI_BACKGROUND(),
-	UI_ICON_LEFT(0x00, BAGL_GLYPH_ICON_CROSS),
-	UI_ICON_RIGHT(0x00, BAGL_GLYPH_ICON_CHECK),
-
-	UI_TEXT(0x00, 0, 18, 128, "Sign transaction?"),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CHECK),
+	UI_TEXT(0x00, 0, 12, 128, "Approve?"),
 };
 
-static const bagl_element_t* ui_prepro_signTxn_approve(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
 
-static unsigned int ui_signTxn_approve_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int adpu_tx;
+static const bagl_element_t ui_signTxn_deny[] = {
+	UI_BACKGROUND(),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CROSS),
+	UI_TEXT(0x00, 0, 12, 128, "Deny transaction?"),
+};
+
+static unsigned int ui_signTxn_deny_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		// make sure there's no data in the office
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_signature(LAST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_LEFT | BUTTON_EVT_FAST:
+        break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            local_load_wallet(FIRST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_FAST: // SEEK RIGHT
+        break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        // keeps the screen from flipping around after being denied
+        global.lock = true;
+        // make sure there's no data in the buffer
 		memset(G_io_apdu_buffer, 0, IO_APDU_BUFFER_SIZE);
 		// send a single 0 byte to differentiate from app not running
 		io_exchange_with_code(SW_OK, 1);
 		ui_idle();
 		break;
+	}
+	return 0;
+}
 
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		adpu_tx = create_helium_pay_txn(CTX.account_index);
+static unsigned int ui_signTxn_approve_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	int adpu_tx;
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_fee(LAST);
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_deny(LAST);
+        }
+		break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        global.lock = true;
+        adpu_tx = create_helium_pay_txn(global.account_index);
 		io_exchange_with_code(SW_OK, adpu_tx);
 		ui_idle();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
 		break;
 	}
 	return 0;
@@ -60,44 +98,28 @@ static const bagl_element_t ui_displayFee[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Data Credit Fee"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of fee
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayFee(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
 static unsigned int ui_displayFee_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_payment_memo,
+            &load_signature
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-		// display approval screen
-		UX_DISPLAY(ui_signTxn_approve, ui_prepro_signTxn_approve);
+    case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_payment_memo,
+            &load_signature
+        );
+        UX_REDISPLAY();
 		break;
 	}
 	return 0;
@@ -107,59 +129,30 @@ static const bagl_element_t ui_displayMemo[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Payment Memo"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of fee
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayMemo(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
 static unsigned int ui_displayMemo_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-    uint8_t len;
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_recipient,
+            &load_fee
+        );
+        UX_REDISPLAY();
+        break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_recipient,
+            &load_fee
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-        // display data credit transaction fee
-		len = bin2dec(CTX.fullStr, CTX.fee);
-		CTX.fullStr_len = len;
-		CTX.fullStr[len] = '\0';
-
-		uint8_t partlen = 12;
-		if(len < 12){
-			partlen = len;
-		}
-		memmove(CTX.partialStr, CTX.fullStr, partlen);
-		CTX.partialStr[partlen] = '\0';
-		CTX.displayIndex = 0;
-		// display fee
-		UX_DISPLAY(ui_displayFee, ui_prepro_displayFee);
-		break;
-	}
+    }
 	return 0;
 }
 
@@ -167,60 +160,30 @@ static const bagl_element_t ui_displayRecipient[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Recipient Address"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of the recipient
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayRecipient(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
 static unsigned int ui_displayRecipient_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	uint8_t len;
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_amount,
+            &load_payment_memo
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_amount,
+            &load_payment_memo
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-		// display burn memo
-		len = u64_to_base64(CTX.fullStr, CTX.memo);
-		CTX.fullStr_len = len;
-		CTX.fullStr[len] = '\0';
-
-		uint8_t partlen = 12;
-		if(len < 12){
-			partlen = len;
-		}
-		memmove(CTX.partialStr, CTX.fullStr, partlen);
-		CTX.partialStr[partlen] = '\0';
-		CTX.displayIndex = 0;
-
-		UX_DISPLAY(ui_displayMemo, ui_prepro_displayMemo);
-		break;
-	}
+    }
 	return 0;
 }
 
@@ -228,95 +191,167 @@ static const bagl_element_t ui_displayAmount[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-#ifdef HELIUM_TESTNET
-	UI_TEXT(0x00, 0, 12, 128, "Amount TNT"),
-#else
-	UI_TEXT(0x00, 0, 12, 128, "Amount HNT"),
-#endif
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of the amount
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayAmount(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
+static unsigned int ui_displayAmount_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+    switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &local_load_wallet,
+            &load_recipient
+        );
+        UX_REDISPLAY();
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &local_load_wallet,
+            &load_recipient
+        );
+        UX_REDISPLAY();
+		break;
+    }
+	return 0;
 }
 
-static unsigned int ui_displayAmount_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	cx_sha256_t hash;
-	unsigned char hash_buffer[32];
-	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
-	uint8_t * address_with_check = G_io_apdu_buffer;
+static const bagl_element_t ui_getPublicKey[] = {
+	UI_BACKGROUND(),
+	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the public key or address.
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
+};
 
+// Define the button handler for the comparison screen. Again, this is nearly
+// identical to the signHash comparison button handler.
+static unsigned int ui_getPublicKey_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        if (!global.lock) {
+            change_page(
+                PREV,
+                &load_deny,
+                &load_amount
+            );
+        }
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        if (!global.lock) {
+            change_page(
+                NEXT,
+                &load_deny,
+                &load_amount
+            );
+        }
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-		for(uint8_t i=0; i<2; i++){
-			// display recipient address on screen
-			memmove(address_with_check, CTX.payee, 34);
-
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
-			memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-			size_t output_len;
-			btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-			CTX.fullStr[output_len] = '\0';
-			CTX.fullStr_len = output_len;
-			memmove(CTX.partialStr, CTX.fullStr, 12);
-			CTX.partialStr[12] = '\0';
-			CTX.displayIndex = 0;
-
-			UX_DISPLAY(ui_displayRecipient, ui_prepro_displayRecipient);
-		}
-
-		break;
-	}
+    }
 	return 0;
+}
+
+static void local_load_wallet(page_cmd_t page_cmd) {
+    load_wallet(page_cmd, load_deny, load_amount);
+    UX_DISPLAY(ui_getPublicKey, NULL);
 }
 
 void handle_sign_payment_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength,
                              volatile unsigned int *flags, __attribute__((unused)) volatile unsigned int *tx) {
+
     if(save_payment_context(p1, p2, dataBuffer, dataLength, &CTX)) {
-        // display amount on screen
-        uint8_t len = pretty_print_hnt(CTX.fullStr, CTX.amount);
-        uint8_t i = 0;
-        while(CTX.fullStr[i] != '\0' && i<12){
-            CTX.partialStr[i] = CTX.fullStr[i];
-            i++;
-        }
-        CTX.partialStr[i] = '\0';
-        CTX.fullStr_len = len;
-        CTX.displayIndex = 0;
-        UX_DISPLAY(ui_displayAmount, ui_prepro_displayAmount);
+        local_load_wallet(FIRST);
     } else {
         display_error();
     }
 	*flags |= IO_ASYNCH_REPLY;
+}
+
+static void load_fee(page_cmd_t page_cmd) {
+    uint8_t len = bin2dec(global.fullStr, CTX.fee);
+    global.title_len = sizeof("DC Fee (1/n)");
+    memcpy(global.title, &"DC Fee (1/n)", global.title_len);
+    global.fullStr_len = len;
+    global.fullStr[len] = '\0';
+    global.displayIndex = 0;
+    change_page(
+        page_cmd,
+        &load_payment_memo,
+        &load_signature
+    );
+    UX_DISPLAY(ui_displayFee, NULL);
+}
+
+static void load_recipient(page_cmd_t page_cmd) {
+	cx_sha256_t hash;
+	unsigned char hash_buffer[32];
+	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
+	uint8_t * address_with_check = G_io_apdu_buffer;
+    global.title_len = sizeof("Recipient (1/n)");
+    memcpy(global.title, &"Recipient (1/n)", global.title_len);
+    for(uint8_t i=0; i<2; i++){
+        memmove(address_with_check, CTX.payee, 34);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
+        memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
+        size_t output_len;
+        btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+        global.fullStr[output_len] = '\0';
+        global.fullStr_len = output_len;
+        change_page(
+            page_cmd,
+            &load_amount,
+            &load_payment_memo
+        );
+    }
+    UX_DISPLAY(ui_displayRecipient, NULL);
+}
+
+static void load_payment_memo(page_cmd_t page_cmd){
+    global.title_len = sizeof("Memo (1/n)");
+    memcpy(global.title, &"Memo (1/n)", global.title_len);
+    uint8_t len = u64_to_base64(global.fullStr, CTX.memo);
+    global.fullStr_len = len;
+    global.fullStr[len] = '\0';
+    change_page(
+        page_cmd,
+        &load_recipient,
+        &load_fee
+    );
+    UX_DISPLAY(ui_displayMemo, NULL);
+}
+
+static void load_amount(page_cmd_t page_cmd){
+    #ifdef HELIUM_TESTNET
+    global.title_len = sizeof("Amount TNT (1/n)");
+    memcpy(global.title, &"Amount TNT (1/n)", global.title_len);
+    #else
+    global.title_len = sizeof("Amount HNT (1/n)");
+    memcpy(global.title, &"Amount HNT (1/n)", global.title_len);
+    #endif
+    // display amount on screen
+    uint8_t len = pretty_print_hnt(global.fullStr, CTX.amount);
+    global.fullStr_len = len;
+    change_page(
+        page_cmd,
+        &load_signature,
+        &load_recipient
+    );
+    UX_DISPLAY(ui_displayAmount, NULL);
+}
+
+static void load_signature(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_approve, NULL);
+}
+
+static void load_deny(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_deny, NULL);
 }
 
 #endif

--- a/src/ux/nanos/nanos_transfer_sec.c
+++ b/src/ux/nanos/nanos_transfer_sec.c
@@ -12,45 +12,81 @@
 #include "save_context.h"
 #include "nanos_error.h"
 
-#define CTX global.transferSecContext
+#define CTX cmd.transferSecContext
+
+static void load_amount(page_cmd_t page_cmd);
+static void load_recipient(page_cmd_t page_cmd);
+static void load_fee(page_cmd_t page_cmd);
+static void load_signature(page_cmd_t page_cmd);
+static void load_deny(page_cmd_t page_cmd);
+static void local_load_wallet(page_cmd_t page_cmd);
 
 static const bagl_element_t ui_signTxn_approve[] = {
 	UI_BACKGROUND(),
-	UI_ICON_LEFT(0x00, BAGL_GLYPH_ICON_CROSS),
-	UI_ICON_RIGHT(0x00, BAGL_GLYPH_ICON_CHECK),
-
-	UI_TEXT(0x00, 0, 18, 128, "Sign transaction?"),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CHECK),
+	UI_TEXT(0x00, 0, 12, 128, "Approve?"),
 };
 
-static const bagl_element_t* ui_prepro_signTxn_approve(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
 
-static unsigned int ui_signTxn_approve_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int adpu_tx;
+static const bagl_element_t ui_signTxn_deny[] = {
+	UI_BACKGROUND(),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CROSS),
+	UI_TEXT(0x00, 0, 12, 128, "Deny transaction?"),
+};
+
+static unsigned int ui_signTxn_deny_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		// make sure there's no data in the office
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_signature(LAST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_LEFT | BUTTON_EVT_FAST:
+        break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            local_load_wallet(FIRST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_FAST: // SEEK RIGHT
+        break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        // keeps the screen from flipping around after being denied
+        global.lock = true;
+        // make sure there's no data in the buffer
 		memset(G_io_apdu_buffer, 0, IO_APDU_BUFFER_SIZE);
 		// send a single 0 byte to differentiate from app not running
 		io_exchange_with_code(SW_OK, 1);
 		ui_idle();
 		break;
+	}
+	return 0;
+}
 
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		adpu_tx = create_helium_transfer_sec(CTX.account_index);
+static unsigned int ui_signTxn_approve_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	int adpu_tx;
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_fee(LAST);
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_deny(LAST);
+        }
+		break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        global.lock = true;
+        adpu_tx = create_helium_transfer_sec(global.account_index);
 		io_exchange_with_code(SW_OK, adpu_tx);
 		ui_idle();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
 		break;
 	}
 	return 0;
@@ -60,44 +96,28 @@ static const bagl_element_t ui_displayFee[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Data Credit Fee"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of fee
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayFee(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
-static unsigned int ui_displayFee_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
+static unsigned int ui_displayFee_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_fee,
+            &load_signature
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-		// display approval screen
-		UX_DISPLAY(ui_signTxn_approve, ui_prepro_signTxn_approve);
+    case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_fee,
+            &load_signature
+        );
+        UX_REDISPLAY();
 		break;
 	}
 	return 0;
@@ -107,60 +127,30 @@ static const bagl_element_t ui_displayRecipient[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Recipient Address"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of the recipient
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayRecipient(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
-static unsigned int ui_displayRecipient_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	uint8_t len;
+static unsigned int ui_displayRecipient_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_amount,
+            &load_fee
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_amount,
+            &load_fee
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-		// display data credit transaction fee
-		len = bin2dec(CTX.fullStr, CTX.fee);
-		CTX.fullStr_len = len;
-		CTX.fullStr[len] = '\0';
-
-		uint8_t partlen = 12;
-		if(len < 12){
-			partlen = len;
-		}
-		memmove(CTX.partialStr, CTX.fullStr, partlen);
-		CTX.partialStr[partlen] = '\0';
-		CTX.displayIndex = 0;
-
-		UX_DISPLAY(ui_displayFee, ui_prepro_displayFee);
-		break;
-	}
+    }
 	return 0;
 }
 
@@ -168,98 +158,152 @@ static const bagl_element_t ui_displayAmount[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-#ifdef HELIUM_TESTNET
-	UI_TEXT(0x00, 0, 12, 128, "Amount TST"),
-#else
-	UI_TEXT(0x00, 0, 12, 128, "Amount HST"),
-#endif
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of the amount
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayAmount(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
+static unsigned int ui_displayAmount_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+    switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &local_load_wallet,
+            &load_recipient
+        );
+        UX_REDISPLAY();
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &local_load_wallet,
+            &load_recipient
+        );
+        UX_REDISPLAY();
+		break;
+    }
+	return 0;
 }
 
-static unsigned int ui_displayAmount_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
+static const bagl_element_t ui_getPublicKey[] = {
+	UI_BACKGROUND(),
+	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the public key or address.
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
+};
+
+// Define the button handler for the comparison screen. Again, this is nearly
+// identical to the signHash comparison button handler.
+static unsigned int ui_getPublicKey_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        if (!global.lock) {
+            change_page(
+                PREV,
+                &load_deny,
+                &load_amount
+            );
+        }
+		UX_REDISPLAY();
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        if (!global.lock) {
+            change_page(
+                NEXT,
+                &load_deny,
+                &load_amount
+            );
+        }
+		UX_REDISPLAY();
+		break;
+    }
+	return 0;
+}
+
+static void local_load_wallet(page_cmd_t page_cmd) {
+    load_wallet(page_cmd, load_deny, load_amount);
+    UX_DISPLAY(ui_getPublicKey, NULL);
+}
+
+void handle_sign_transfer_sec_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength,
+                             volatile unsigned int *flags, __attribute__((unused)) volatile unsigned int *tx) {
+    if(save_transfer_sec_context(p1, p2, dataBuffer, dataLength, &CTX)) {
+        local_load_wallet(FIRST);
+    } else {
+        display_error();
+    }
+	*flags |= IO_ASYNCH_REPLY;
+}
+
+static void load_fee(page_cmd_t page_cmd) {
+    uint8_t len = bin2dec(global.fullStr, CTX.fee);
+    global.title_len = sizeof("DC Fee (1/n)");
+    memcpy(global.title, &"DC Fee (1/n)", global.title_len);
+    global.fullStr_len = len;
+    global.fullStr[len] = '\0';
+    global.displayIndex = 0;
+    change_page(
+        page_cmd,
+        &load_recipient,
+        &load_signature
+    );
+    UX_DISPLAY(ui_displayFee, NULL);
+}
+
+static void load_recipient(page_cmd_t page_cmd) {
 	cx_sha256_t hash;
 	unsigned char hash_buffer[32];
 	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
 	uint8_t * address_with_check = G_io_apdu_buffer;
-
-	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-		for(uint8_t i=0; i<2; i++){
-			// display recipient address on screen
-			memmove(address_with_check, CTX.payee, 34);
-
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
-			memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-			size_t output_len;
-			btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-			CTX.fullStr[output_len] = '\0';
-			CTX.fullStr_len = output_len;
-			memmove(CTX.partialStr, CTX.fullStr, 12);
-			CTX.partialStr[12] = '\0';
-			CTX.displayIndex = 0;
-
-			UX_DISPLAY(ui_displayRecipient, ui_prepro_displayRecipient);
-		}
-
-		break;
-	}
-	return 0;
+    global.title_len = sizeof("Recipient (1/n)");
+    memcpy(global.title, &"Recipient (1/n)", global.title_len);
+    for(uint8_t i=0; i<2; i++){
+        memmove(address_with_check, CTX.payee, 34);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
+        memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
+        size_t output_len;
+        btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+        global.fullStr[output_len] = '\0';
+        global.fullStr_len = output_len;
+        change_page(
+            page_cmd,
+            &load_amount,
+            &load_signature
+        );
+    }
+    UX_DISPLAY(ui_displayRecipient, NULL);
 }
 
-void handle_sign_transfer_sec_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags,  __attribute__((unused))  volatile unsigned int *tx) {
-    if(save_transfer_sec_context(p1, p2, dataBuffer, dataLength, &CTX)) {
-        // display amount on screen
-        // hst and hnt share the same amount of decimals so
-        // the pretty_print_hnt function works here too
-        uint8_t len = pretty_print_hnt(CTX.fullStr, CTX.amount);
-        uint8_t i = 0;
-        while(CTX.fullStr[i] != '\0' && i<12){
-            CTX.partialStr[i] = CTX.fullStr[i];
-            i++;
-        }
-        CTX.partialStr[i] = '\0';
-        CTX.fullStr_len = len;
+static void load_amount(page_cmd_t page_cmd){
+    #ifdef HELIUM_TESTNET
+    global.title_len = sizeof("Amount TST (1/n)");
+    memcpy(global.title, &"Amount TST (1/n)", global.title_len);
+    #else
+    global.title_len = sizeof("Amount HST (1/n)");
+    memcpy(global.title, &"Amount HST (1/n)", global.title_len);
+    #endif
+    // display amount on screen
+    uint8_t len = pretty_print_hnt(global.fullStr, CTX.amount);
+    global.fullStr_len = len;
+    change_page(
+        page_cmd,
+        &load_signature,
+        &load_recipient
+    );
+    UX_DISPLAY(ui_displayAmount, NULL);
+}
 
-        CTX.displayIndex = 0;
+static void load_signature(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_approve, NULL);
+}
 
-        UX_DISPLAY(ui_displayAmount, ui_prepro_displayAmount);
-    } else {
-        display_error();
-    }
-    *flags |= IO_ASYNCH_REPLY;
+static void load_deny(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_deny, NULL);
 }
 
 #endif

--- a/src/ux/nanos/nanos_validator_stake_txn.c
+++ b/src/ux/nanos/nanos_validator_stake_txn.c
@@ -12,45 +12,81 @@
 #include "save_context.h"
 #include "nanos_error.h"
 
-#define CTX global.stakeValidatorContext
+#define CTX cmd.stakeValidatorContext
+
+static void load_amount(page_cmd_t page_cmd);
+static void load_stake_addr(page_cmd_t page_cmd);
+static void load_fee(page_cmd_t page_cmd);
+static void load_signature(page_cmd_t page_cmd);
+static void load_deny(page_cmd_t page_cmd);
+static void local_load_wallet(page_cmd_t page_cmd);
 
 static const bagl_element_t ui_signTxn_approve[] = {
 	UI_BACKGROUND(),
-	UI_ICON_LEFT(0x00, BAGL_GLYPH_ICON_CROSS),
-	UI_ICON_RIGHT(0x00, BAGL_GLYPH_ICON_CHECK),
-
-	UI_TEXT(0x00, 0, 18, 128, "Sign transaction?"),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CHECK),
+	UI_TEXT(0x00, 0, 12, 128, "Approve?"),
 };
 
-static const bagl_element_t* ui_prepro_signTxn_approve(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
 
-static unsigned int ui_signTxn_approve_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int adpu_tx;
+static const bagl_element_t ui_signTxn_deny[] = {
+	UI_BACKGROUND(),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CROSS),
+	UI_TEXT(0x00, 0, 12, 128, "Deny transaction?"),
+};
+
+static unsigned int ui_signTxn_deny_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		// make sure there's no data in the office
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_signature(LAST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_LEFT | BUTTON_EVT_FAST:
+        break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            local_load_wallet(FIRST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_FAST: // SEEK RIGHT
+        break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        // keeps the screen from flipping around after being denied
+        global.lock = true;
+        // make sure there's no data in the buffer
 		memset(G_io_apdu_buffer, 0, IO_APDU_BUFFER_SIZE);
 		// send a single 0 byte to differentiate from app not running
 		io_exchange_with_code(SW_OK, 1);
 		ui_idle();
 		break;
+	}
+	return 0;
+}
 
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		adpu_tx = create_helium_stake_txn(CTX.account_index);
+static unsigned int ui_signTxn_approve_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	int adpu_tx;
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_fee(LAST);
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_deny(LAST);
+        }
+		break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        global.lock = true;
+        adpu_tx = create_helium_stake_txn(global.account_index);
 		io_exchange_with_code(SW_OK, adpu_tx);
 		ui_idle();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
 		break;
 	}
 	return 0;
@@ -60,44 +96,28 @@ static const bagl_element_t ui_displayFee[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Data Credit Fee"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of fee
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayFee(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
-static unsigned int ui_displayFee_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
+static unsigned int ui_displayFee_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_fee,
+            &load_signature
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-		// display approval screen
-		UX_DISPLAY(ui_signTxn_approve, ui_prepro_signTxn_approve);
+    case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_fee,
+            &load_signature
+        );
+        UX_REDISPLAY();
 		break;
 	}
 	return 0;
@@ -107,60 +127,30 @@ static const bagl_element_t ui_displayRecipient[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Stake Address"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of the recipient
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayRecipient(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
-static unsigned int ui_displayRecipient_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	uint8_t len;
+static unsigned int ui_displayRecipient_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_amount,
+            &load_fee
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_amount,
+            &load_fee
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-		// display data credit transaction fee
-		len = bin2dec(CTX.fullStr, CTX.fee);
-		CTX.fullStr_len = len;
-		CTX.fullStr[len] = '\0';
-		
-		uint8_t partlen = 12;
-		if(len < 12){
-			partlen = len;
-		}
-		memmove(CTX.partialStr, CTX.fullStr, partlen);
-		CTX.partialStr[partlen] = '\0';
-		CTX.displayIndex = 0;
-
-		UX_DISPLAY(ui_displayFee, ui_prepro_displayFee);
-		break;
-	}
+    }
 	return 0;
 }
 
@@ -168,96 +158,153 @@ static const bagl_element_t ui_displayAmount[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-#ifdef HELIUM_TESTNET
-	UI_TEXT(0x00, 0, 12, 128, "Stake TNT"),
-#else
-	UI_TEXT(0x00, 0, 12, 128, "Stake HNT"),
-#endif
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of the amount
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayAmount(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
+static unsigned int ui_displayAmount_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+    switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &local_load_wallet,
+            &load_stake_addr
+        );
+        UX_REDISPLAY();
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &local_load_wallet,
+            &load_stake_addr
+        );
+        UX_REDISPLAY();
+		break;
+    }
+	return 0;
 }
 
-static unsigned int ui_displayAmount_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
+static const bagl_element_t ui_getPublicKey[] = {
+	UI_BACKGROUND(),
+	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the public key or address.
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
+};
+
+// Define the button handler for the comparison screen. Again, this is nearly
+// identical to the signHash comparison button handler.
+static unsigned int ui_getPublicKey_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        if (!global.lock) {
+            change_page(
+                PREV,
+                &load_deny,
+                &load_amount
+            );
+        }
+		UX_REDISPLAY();
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        if (!global.lock) {
+            change_page(
+                NEXT,
+                &load_deny,
+                &load_amount
+            );
+        }
+		UX_REDISPLAY();
+		break;
+    }
+	return 0;
+}
+
+static void local_load_wallet(page_cmd_t page_cmd) {
+    load_wallet(page_cmd, load_deny, load_amount);
+    UX_DISPLAY(ui_getPublicKey, NULL);
+}
+
+void handle_stake_validator_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength,
+                             volatile unsigned int *flags, __attribute__((unused)) volatile unsigned int *tx) {
+
+    if(save_stake_validator_context(p1, p2, dataBuffer, dataLength, &CTX)) {
+        local_load_wallet(FIRST);
+    } else {
+        display_error();
+    }
+	*flags |= IO_ASYNCH_REPLY;
+}
+
+static void load_fee(page_cmd_t page_cmd) {
+    uint8_t len = bin2dec(global.fullStr, CTX.fee);
+    global.title_len = sizeof("DC Fee (1/n)");
+    memcpy(global.title, &"DC Fee (1/n)", global.title_len);
+    global.fullStr_len = len;
+    global.fullStr[len] = '\0';
+    global.displayIndex = 0;
+    change_page(
+        page_cmd,
+        &load_fee,
+        &load_signature
+    );
+    UX_DISPLAY(ui_displayFee, NULL);
+}
+
+static void load_stake_addr(page_cmd_t page_cmd) {
 	cx_sha256_t hash;
 	unsigned char hash_buffer[32];
 	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
 	uint8_t * address_with_check = G_io_apdu_buffer;
-
-	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-		for(uint8_t i=0; i<2; i++){
-			// display recipient address on screen
-			memmove(address_with_check, CTX.address, 34);
-
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
-			memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-			size_t output_len;
-			btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-			CTX.fullStr[output_len] = '\0';
-			CTX.fullStr_len = output_len;
-			memmove(CTX.partialStr, CTX.fullStr, 12);
-			CTX.partialStr[12] = '\0';
-			CTX.displayIndex = 0;
-
-			UX_DISPLAY(ui_displayRecipient, ui_prepro_displayRecipient);
-		}
-
-		break;
-	}
-	return 0;
+    global.title_len = sizeof("Stake Addr (1/n)");
+    memcpy(global.title, &"Stake Addr (1/n)", global.title_len);
+    for(uint8_t i=0; i<2; i++){
+        memmove(address_with_check, CTX.address, 34);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
+        memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
+        size_t output_len;
+        btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+        global.fullStr[output_len] = '\0';
+        global.fullStr_len = output_len;
+        change_page(
+            page_cmd,
+            &load_amount,
+            &load_fee
+        );
+    }
+    UX_DISPLAY(ui_displayRecipient, NULL);
 }
 
-void handle_stake_validator_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags, __attribute__((unused)) volatile unsigned int *tx) {
-    if(save_stake_validator_context(p1,p2,dataBuffer, dataLength, &CTX)) {
-        // display amount on screen
-        uint8_t len = pretty_print_hnt(CTX.fullStr, CTX.stake);
-        uint8_t i = 0;
-        while(CTX.fullStr[i] != '\0' && i<12){
-            CTX.partialStr[i] = CTX.fullStr[i];
-            i++;
-        }
-        CTX.partialStr[i] = '\0';
-        CTX.fullStr_len = len;
+static void load_amount(page_cmd_t page_cmd){
+    #ifdef HELIUM_TESTNET
+    global.title_len = sizeof("Stake TNT (1/n)");
+    memcpy(global.title, &"Stake TNT (1/n)", global.title_len);
+    #else
+    global.title_len = sizeof("Stake HNT (1/n)");
+    memcpy(global.title, &"Stake HNT (1/n)", global.title_len);
+    #endif
+    // display amount on screen
+    uint8_t len = pretty_print_hnt(global.fullStr, CTX.stake);
+    global.fullStr_len = len;
+    change_page(
+        page_cmd,
+        &load_signature,
+        &load_stake_addr
+    );
+    UX_DISPLAY(ui_displayAmount, NULL);
+}
 
-        CTX.displayIndex = 0;
+static void load_signature(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_approve, NULL);
+}
 
-        UX_DISPLAY(ui_displayAmount, ui_prepro_displayAmount);
-    } else {
-        display_error();
-    }
-    *flags |= IO_ASYNCH_REPLY;
+static void load_deny(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_deny, NULL);
 }
 
 #endif

--- a/src/ux/nanos/nanos_validator_txfer_txn.c
+++ b/src/ux/nanos/nanos_validator_txfer_txn.c
@@ -12,113 +12,84 @@
 #include "save_context.h"
 #include "nanos_error.h"
 
-#define ADDRESS_SWITCH( NAME, NEXT, ADDRESS ) \
-    static void NAME() {                      \
-        cx_sha256_t hash;\
-        unsigned char hash_buffer[32];        \
-        uint8_t * address_with_check = G_io_apdu_buffer;\
-        for(uint8_t i=0; i<2; i++){\
-            memmove(address_with_check,(ADDRESS), 34);\
-            cx_sha256_init(&hash);\
-            cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);\
-            cx_sha256_init(&hash);\
-            cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);\
-            memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);\
-            size_t output_len;\
-            btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);\
-            CTX.fullStr[output_len] = '\0';\
-            CTX.fullStr_len = output_len;\
-            memmove(CTX.partialStr, CTX.fullStr, 12);\
-            CTX.partialStr[12] = '\0';\
-            CTX.displayIndex = 0;\
-            UX_DISPLAY(ui_##NEXT, ui_prepro_##NEXT);\
-        }                                          \
-    }                                          \
+#define CTX cmd.transferValidatorContext
 
-
-#define ADDRESS_DISPLAY( DESCRIPTION, NAME, SWITCH ) \
-    static const bagl_element_t ui_##NAME[] = { \
-        UI_BACKGROUND(), \
-        UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT), \
-        UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT), \
-        UI_TEXT(0x00, 0, 12, 128, #DESCRIPTION), \
-        UI_TEXT(0x00, 0, 26, 128, CTX.partialStr), \
-    }; \
-\
-    static const bagl_element_t* ui_prepro_##NAME(const bagl_element_t *element) { \
-    int fullSize = CTX.fullStr_len; \
-    if ((element->component.userid == 1 && CTX.displayIndex == 0) ||\
-            (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {\
-            return NULL;\
-        }\
-        return element;\
-    }\
-\
-    static unsigned int ui_##NAME##_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {\
-        int fullSize = CTX.fullStr_len;\
-        switch (button_mask) {\
-        case BUTTON_LEFT:\
-        case BUTTON_EVT_FAST | BUTTON_LEFT:\
-            if (CTX.displayIndex > 0) {\
-                CTX.displayIndex--;\
-            }\
-            memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);\
-            UX_REDISPLAY();\
-            break;\
-        case BUTTON_RIGHT:\
-        case BUTTON_EVT_FAST | BUTTON_RIGHT:\
-            if (CTX.displayIndex < fullSize-12) {\
-                CTX.displayIndex++;\
-            }\
-            memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);\
-            UX_REDISPLAY();\
-            break;\
-        case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:\
-            SWITCH(); \
-            break;\
-        }\
-        return 0;\
-    }\
-
-
-#define CTX global.transferValidatorContext
+static void load_stake_amount(page_cmd_t page_cmd);
+static void load_old_stake_addr(page_cmd_t page_cmd);
+static void load_new_stake_addr(page_cmd_t page_cmd);
+static void load_new_owner(page_cmd_t page_cmd);
+static void load_payment_amount(page_cmd_t page_cmd);
+static void load_fee(page_cmd_t page_cmd);
+static void load_signature(page_cmd_t page_cmd);
+static void load_deny(page_cmd_t page_cmd);
+static void local_load_wallet(page_cmd_t page_cmd);
 
 static const bagl_element_t ui_signTxn_approve[] = {
 	UI_BACKGROUND(),
-	UI_ICON_LEFT(0x00, BAGL_GLYPH_ICON_CROSS),
-	UI_ICON_RIGHT(0x00, BAGL_GLYPH_ICON_CHECK),
-
-	UI_TEXT(0x00, 0, 18, 128, "Sign transaction?"),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CHECK),
+	UI_TEXT(0x00, 0, 12, 128, "Approve?"),
 };
 
-static const bagl_element_t* ui_prepro_signTxn_approve(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
 
-static unsigned int ui_signTxn_approve_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int adpu_tx;
+static const bagl_element_t ui_signTxn_deny[] = {
+	UI_BACKGROUND(),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CROSS),
+	UI_TEXT(0x00, 0, 12, 128, "Deny transaction?"),
+};
+
+static unsigned int ui_signTxn_deny_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		// make sure there's no data in the office
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_signature(LAST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_LEFT | BUTTON_EVT_FAST:
+        break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            local_load_wallet(FIRST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_FAST: // SEEK RIGHT
+        break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        // keeps the screen from flipping around after being denied
+        global.lock = true;
+        // make sure there's no data in the buffer
 		memset(G_io_apdu_buffer, 0, IO_APDU_BUFFER_SIZE);
 		// send a single 0 byte to differentiate from app not running
 		io_exchange_with_code(SW_OK, 1);
 		ui_idle();
 		break;
+	}
+	return 0;
+}
 
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		adpu_tx = create_helium_transfer_validator_txn(CTX.account_index);
-		io_exchange_with_code(SW_OK, adpu_tx);
-		ui_idle();
+static unsigned int ui_signTxn_approve_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	int adpu_tx;
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_fee(LAST);
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_deny(LAST);
+        }
 		break;
 	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        global.lock = true;
+        adpu_tx = create_helium_transfer_validator_txn(global.account_index);
+		io_exchange_with_code(SW_OK, adpu_tx);
+		ui_idle();
 		break;
 	}
 	return 0;
@@ -128,153 +99,131 @@ static const bagl_element_t ui_displayFee[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Data Credit Fee"),
-	// The visible portion of fee
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayFee(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
-static unsigned int ui_displayFee_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
+static unsigned int ui_displayFee_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_new_stake_addr,
+            &load_signature
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-		// display approval screen
-		UX_DISPLAY(ui_signTxn_approve, ui_prepro_signTxn_approve);
+    case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_new_stake_addr,
+            &load_signature
+        );
+        UX_REDISPLAY();
 		break;
 	}
 	return 0;
 }
 
-
-static void dataCreditFeeSwitch() {
-    uint8_t len;
-
-    // display data credit transaction fee
-    len = bin2dec(CTX.fullStr, CTX.fee);
-    CTX.fullStr_len = len;
-    CTX.fullStr[len] = '\0';
-
-    uint8_t partlen = 12;
-    if(len < 12){
-        partlen = len;
-    }
-    memmove(CTX.partialStr, CTX.fullStr, partlen);
-    CTX.partialStr[partlen] = '\0';
-    CTX.displayIndex = 0;
-
-    UX_DISPLAY(ui_displayFee, ui_prepro_displayFee);
-};
-
-
-ADDRESS_DISPLAY(New Address, displayNewAddress, dataCreditFeeSwitch);
-
-ADDRESS_SWITCH(oldAddressSwitch, displayNewAddress, CTX.new_address);
-ADDRESS_DISPLAY(Old Address, displayOldAddress, oldAddressSwitch);
-
-ADDRESS_SWITCH(newOwnerSwitch, displayOldAddress, CTX.old_address);
-ADDRESS_DISPLAY(New Owner, displayNewOwner, newOwnerSwitch);
-
-ADDRESS_SWITCH(oldOwnerSwitch, displayNewOwner, CTX.new_owner);
-ADDRESS_DISPLAY(Old Owner, displayOldOwner, oldOwnerSwitch);
-
-static const bagl_element_t ui_displayPayment[] = {
+static const bagl_element_t ui_displayNewOwner[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-#ifdef HELIUM_TESTNET
-	UI_TEXT(0x00, 0, 12, 128, "TNT Paid to Old Owner"),
-#else
-	UI_TEXT(0x00, 0, 12, 128, "HNT Paid to Old Owner"),
-#endif
-	// The visible portion of the amount
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the recipient
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayPayment(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
+static unsigned int ui_displayNewOwner_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_payment_amount,
+            &load_new_stake_addr
+        );
+		UX_REDISPLAY();
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_payment_amount,
+            &load_new_stake_addr
+        );
+		UX_REDISPLAY();
+		break;
+    }
+	return 0;
 }
 
-static unsigned int ui_displayPayment_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	cx_sha256_t hash;
-	unsigned char hash_buffer[32];
-	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
-	uint8_t * address_with_check = G_io_apdu_buffer;
+static const bagl_element_t ui_displayNewStakeAddr[] = {
+	UI_BACKGROUND(),
+	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the recipient
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
+};
+
+static unsigned int ui_displayNewStakeAddr_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+    void (*prev)(page_cmd_t);
+    // if old_owner and new_owner are the same, we skip back to
+    // stake amount instead of new_owner
+    if(memcmp(&CTX.old_owner[1], &CTX.new_owner[1], 33) == 0) {
+        prev = &load_stake_amount;
+    } else {
+        prev = &load_new_owner;
+    }
 
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            prev,
+            &load_fee
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            prev,
+            &load_fee
+        );
 		UX_REDISPLAY();
 		break;
+    }
+	return 0;
+}
 
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
+static const bagl_element_t ui_displayOldStakeAddr[] = {
+	UI_BACKGROUND(),
+	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the recipient
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
+};
 
-		for(uint8_t i=0; i<2; i++){
-			// display recipient address on screen
-			memmove(address_with_check, CTX.old_owner, 34);
-
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
-			memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-			size_t output_len;
-			btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-			CTX.fullStr[output_len] = '\0';
-			CTX.fullStr_len = output_len;
-			memmove(CTX.partialStr, CTX.fullStr, 12);
-			CTX.partialStr[12] = '\0';
-			CTX.displayIndex = 0;
-
-			UX_DISPLAY(ui_displayOldOwner, ui_prepro_displayOldOwner);
-		}
-
+static unsigned int ui_displayOldStakeAddr_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_stake_amount,
+            &load_new_stake_addr
+        );
+		UX_REDISPLAY();
 		break;
-	}
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_stake_amount,
+            &load_new_stake_addr
+        );
+		UX_REDISPLAY();
+		break;
+    }
 	return 0;
 }
 
@@ -282,110 +231,263 @@ static const bagl_element_t ui_displayStakeAmount[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-#ifdef HELIUM_TESTNET
-	UI_TEXT(0x00, 0, 12, 128, "Transfer TNT Stake"),
-#else
-	UI_TEXT(0x00, 0, 12, 128, "Transfer HNT Stake"),
-#endif
-	// The visible portion of the amount
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayStakeAmount(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
+static unsigned int ui_displayStakeAmount_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+    void (*next)(page_cmd_t);
+    // if old_owner and new_owner are the same, we skip to old_address
+    if(memcmp(&CTX.old_owner[1], &CTX.new_owner[1], 33) == 0) {
+        next = &load_old_stake_addr;
+    } else {
+        next = &load_payment_amount;
+    }
 
-static unsigned int ui_displayStakeAmount_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	cx_sha256_t hash;
-	unsigned char hash_buffer[32];
-	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
-	uint8_t * address_with_check = G_io_apdu_buffer;
-    uint8_t len;
-
-	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
+    switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &local_load_wallet,
+            next
+        );
+        UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &local_load_wallet,
+            next
+        );
+        UX_REDISPLAY();
 		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-        // if the new_owner and old_owner are the same, then
-        // we can skip the 3 associated screens (owner changes and payments)
-	    if(memcmp(&CTX.old_owner[1], &CTX.new_owner[1], 33) == 0)
-	    {
-			memmove(address_with_check, CTX.old_address, 34);
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
-			memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-			size_t output_len;
-			btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-			CTX.fullStr[output_len] = '\0';
-			CTX.fullStr_len = output_len;
-			memmove(CTX.partialStr, CTX.fullStr, 12);
-			CTX.partialStr[12] = '\0';
-			CTX.displayIndex = 0;
-			UX_DISPLAY(ui_displayOldAddress, ui_prepro_displayOldAddress);
-        } else {
-            // display payment amount on screen
-            len = pretty_print_hnt(CTX.fullStr, CTX.payment_amount);
-            uint8_t i = 0;
-            while(CTX.fullStr[i] != '\0' && i<12){
-                CTX.partialStr[i] = CTX.fullStr[i];
-                i++;
-            }
-            CTX.partialStr[i] = '\0';
-            CTX.fullStr_len = len;
-
-            CTX.displayIndex = 0;
-
-            UX_DISPLAY(ui_displayPayment, ui_prepro_displayPayment);
-        }
-		break;
-	}
+    }
 	return 0;
 }
 
+static const bagl_element_t ui_displayPaymentAmount[] = {
+	UI_BACKGROUND(),
+	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the amount
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
+};
 
-void handle_transfer_validator_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags, __attribute__((unused)) volatile unsigned int *tx) {
-    if(save_transfer_validator_context(p1, p2, dataBuffer, dataLength, &CTX)) {
-        // display amount on screen
-        uint8_t len = pretty_print_hnt(CTX.fullStr, CTX.stake_amount);
-        uint8_t i = 0;
-        while(CTX.fullStr[i] != '\0' && i<12){
-            CTX.partialStr[i] = CTX.fullStr[i];
-            i++;
+static unsigned int ui_displayPaymentAmount_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+    switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_stake_amount,
+            &load_new_owner
+        );
+        UX_REDISPLAY();
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_stake_amount,
+            &load_new_owner
+        );
+        UX_REDISPLAY();
+		break;
+    }
+	return 0;
+}
+
+static const bagl_element_t ui_getPublicKey[] = {
+	UI_BACKGROUND(),
+	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the public key or address.
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
+};
+
+// Define the button handler for the comparison screen. Again, this is nearly
+// identical to the signHash comparison button handler.
+static unsigned int ui_getPublicKey_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        if (!global.lock) {
+            change_page(
+                PREV,
+                &load_deny,
+                &load_stake_amount
+            );
         }
-        CTX.partialStr[i] = '\0';
-        CTX.fullStr_len = len;
+		UX_REDISPLAY();
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        if (!global.lock) {
+            change_page(
+                NEXT,
+                &load_deny,
+                &load_stake_amount
+            );
+        }
+		UX_REDISPLAY();
+		break;
+    }
+	return 0;
+}
 
-        CTX.displayIndex = 0;
+static void local_load_wallet(page_cmd_t page_cmd) {
+    load_wallet(page_cmd, load_deny, load_stake_amount);
+    UX_DISPLAY(ui_getPublicKey, NULL);
+}
 
-        UX_DISPLAY(ui_displayStakeAmount, ui_prepro_displayStakeAmount);
+void handle_transfer_validator_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength,
+                             volatile unsigned int *flags, __attribute__((unused)) volatile unsigned int *tx) {
+    if(save_transfer_validator_context(p1, p2, dataBuffer, dataLength, &CTX)) {
+        local_load_wallet(FIRST);
     } else {
         display_error();
     }
 	*flags |= IO_ASYNCH_REPLY;
+}
+
+static void load_fee(page_cmd_t page_cmd) {
+    uint8_t len = bin2dec(global.fullStr, CTX.fee);
+    global.title_len = sizeof("DC Fee (1/n)");
+    memcpy(global.title, &"DC Fee (1/n)", global.title_len);
+    global.fullStr_len = len;
+    global.fullStr[len] = '\0';
+    global.displayIndex = 0;
+    change_page(
+        page_cmd,
+        &load_fee,
+        &load_signature
+    );
+    UX_DISPLAY(ui_displayFee, NULL);
+}
+
+static void load_old_stake_addr(page_cmd_t page_cmd) {
+	cx_sha256_t hash;
+	unsigned char hash_buffer[32];
+	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
+	uint8_t * address_with_check = G_io_apdu_buffer;
+    global.title_len = sizeof("Old Stake Addr (1/n)");
+    memcpy(global.title, &"Old Stake Addr (1/n)", global.title_len);
+    for(uint8_t i=0; i<2; i++){
+        memmove(address_with_check, CTX.old_address, 34);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
+        memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
+        size_t output_len;
+        btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+        global.fullStr[output_len] = '\0';
+        global.fullStr_len = output_len;
+        change_page(
+            page_cmd,
+            &load_stake_amount,
+            &load_fee
+        );
+    }
+    UX_DISPLAY(ui_displayOldStakeAddr, NULL);
+}
+
+static void load_new_stake_addr(page_cmd_t page_cmd) {
+	cx_sha256_t hash;
+	unsigned char hash_buffer[32];
+	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
+	uint8_t * address_with_check = G_io_apdu_buffer;
+    global.title_len = sizeof("New Stake Addr (1/n)");
+    memcpy(global.title, &"New Stake Addr (1/n)", global.title_len);
+    for(uint8_t i=0; i<2; i++){
+        memmove(address_with_check, CTX.new_address, 34);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
+        memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
+        size_t output_len;
+        btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+        global.fullStr[output_len] = '\0';
+        global.fullStr_len = output_len;
+        change_page(
+            page_cmd,
+            &load_stake_amount,
+            &load_fee
+        );
+    }
+    UX_DISPLAY(ui_displayNewStakeAddr, NULL);
+}
+
+static void load_new_owner(page_cmd_t page_cmd) {
+	cx_sha256_t hash;
+	unsigned char hash_buffer[32];
+	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
+	uint8_t * address_with_check = G_io_apdu_buffer;
+    global.title_len = sizeof("New Owner (1/n)");
+    memcpy(global.title, &"New Owner (1/n)", global.title_len);
+    for(uint8_t i=0; i<2; i++){
+        memmove(address_with_check, CTX.new_address, 34);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
+        memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
+        size_t output_len;
+        btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+        global.fullStr[output_len] = '\0';
+        global.fullStr_len = output_len;
+        change_page(
+            page_cmd,
+            &load_stake_amount,
+            &load_fee
+        );
+    }
+    UX_DISPLAY(ui_displayNewOwner, NULL);
+}
+
+static void load_stake_amount(page_cmd_t page_cmd){
+    #ifdef HELIUM_TESTNET
+    global.title_len = sizeof("Transfer Stake (1/n)");
+    memcpy(global.title, &"Transfer Stake (1/n)", global.title_len);
+    #else
+    global.title_len = sizeof("Transfer Stake (1/n)");
+    memcpy(global.title, &"Transfer Stake (1/n)", global.title_len);
+    #endif
+    // display amount on screen
+    uint8_t len = pretty_print_hnt(global.fullStr, CTX.stake_amount);
+    global.fullStr_len = len;
+    change_page(
+        page_cmd,
+        &load_signature,
+        &load_old_stake_addr
+    );
+    UX_DISPLAY(ui_displayStakeAmount, NULL);
+}
+
+static void load_payment_amount(page_cmd_t page_cmd){
+    #ifdef HELIUM_TESTNET
+    global.title_len = sizeof("Payment TNT (1/n)");
+    memcpy(global.title, &"Payment TNT (1/n)", global.title_len);
+    #else
+    global.title_len = sizeof("Payment HNT (1/n)");
+    memcpy(global.title, &"Payment HNT (1/n)", global.title_len);
+    #endif
+    // display amount on screen
+    uint8_t len = pretty_print_hnt(global.fullStr, CTX.payment_amount);
+    global.fullStr_len = len;
+    change_page(
+        page_cmd,
+        &load_signature,
+        &load_old_stake_addr
+    );
+    UX_DISPLAY(ui_displayPaymentAmount, NULL);
+}
+
+static void load_signature(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_approve, NULL);
+}
+
+static void load_deny(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_deny, NULL);
 }
 
 #endif

--- a/src/ux/nanos/nanos_validator_unstake_txn.c
+++ b/src/ux/nanos/nanos_validator_unstake_txn.c
@@ -12,45 +12,82 @@
 #include "save_context.h"
 #include "nanos_error.h"
 
-#define CTX global.unstakeValidatorContext
+#define CTX cmd.unstakeValidatorContext
+
+static void load_amount(page_cmd_t page_cmd);
+static void load_recipient(page_cmd_t page_cmd);
+static void load_release_height(page_cmd_t page_cmd);
+static void load_fee(page_cmd_t page_cmd);
+static void load_signature(page_cmd_t page_cmd);
+static void load_deny(page_cmd_t page_cmd);
+static void local_load_wallet(page_cmd_t page_cmd);
 
 static const bagl_element_t ui_signTxn_approve[] = {
 	UI_BACKGROUND(),
-	UI_ICON_LEFT(0x00, BAGL_GLYPH_ICON_CROSS),
-	UI_ICON_RIGHT(0x00, BAGL_GLYPH_ICON_CHECK),
-
-	UI_TEXT(0x00, 0, 18, 128, "Sign transaction?"),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CHECK),
+	UI_TEXT(0x00, 0, 12, 128, "Approve?"),
 };
 
-static const bagl_element_t* ui_prepro_signTxn_approve(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
 
-static unsigned int ui_signTxn_approve_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int adpu_tx;
+static const bagl_element_t ui_signTxn_deny[] = {
+	UI_BACKGROUND(),
+    UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_ICON_CENTER(0x00, BAGL_GLYPH_ICON_CROSS),
+	UI_TEXT(0x00, 0, 12, 128, "Deny transaction?"),
+};
+
+static unsigned int ui_signTxn_deny_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		// make sure there's no data in the office
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_signature(LAST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_LEFT | BUTTON_EVT_FAST:
+        break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            local_load_wallet(FIRST);
+            UX_REDISPLAY();
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_FAST: // SEEK RIGHT
+        break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        // keeps the screen from flipping around after being denied
+        global.lock = true;
+        // make sure there's no data in the buffer
 		memset(G_io_apdu_buffer, 0, IO_APDU_BUFFER_SIZE);
 		// send a single 0 byte to differentiate from app not running
 		io_exchange_with_code(SW_OK, 1);
 		ui_idle();
 		break;
+	}
+	return 0;
+}
 
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		adpu_tx = create_helium_unstake_txn(CTX.account_index);
+static unsigned int ui_signTxn_approve_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	int adpu_tx;
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_fee(LAST);
+        }
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED:
+        if(!global.lock) {
+            load_deny(LAST);
+        }
+		break;
+	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
+        global.lock = true;
+        adpu_tx = create_helium_unstake_txn(global.account_index);
 		io_exchange_with_code(SW_OK, adpu_tx);
 		ui_idle();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
 		break;
 	}
 	return 0;
@@ -60,105 +97,28 @@ static const bagl_element_t ui_displayFee[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Data Credit Fee"),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of fee
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayFee(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
-static unsigned int ui_displayFee_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
+static unsigned int ui_displayFee_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_release_height,
+            &load_signature
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-		// display approval screen
-		UX_DISPLAY(ui_signTxn_approve, ui_prepro_signTxn_approve);
-		break;
-	}
-	return 0;
-}
-
-static const bagl_element_t ui_displayUnstakeAddress[] = {
-	UI_BACKGROUND(),
-	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
-	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Unstake Address"),
-	// The visible portion of the recipient
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
-};
-
-static const bagl_element_t* ui_prepro_displayUnstakeAddress(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
-static unsigned int ui_displayUnstakeAddress_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	uint8_t len;
-	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
-		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-		// display data credit transaction fee
-		len = bin2dec(CTX.fullStr, CTX.fee);
-		CTX.fullStr_len = len;
-		CTX.fullStr[len] = '\0';
-		
-		uint8_t partlen = 12;
-		if(len < 12){
-			partlen = len;
-		}
-		memmove(CTX.partialStr, CTX.fullStr, partlen);
-		CTX.partialStr[partlen] = '\0';
-		CTX.displayIndex = 0;
-
-		UX_DISPLAY(ui_displayFee, ui_prepro_displayFee);
+    case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_release_height,
+            &load_signature
+        );
+        UX_REDISPLAY();
 		break;
 	}
 	return 0;
@@ -168,69 +128,61 @@ static const bagl_element_t ui_displayReleaseHeight[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-	UI_TEXT(0x00, 0, 12, 128, "Stake Release Height"),
-	// The visible portion of the recipient
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of fee
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayReleaseHeight(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
+static unsigned int ui_displayReleaseHeight_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_recipient,
+            &load_fee
+        );
+        UX_REDISPLAY();
+        break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_recipient,
+            &load_fee
+        );
+		UX_REDISPLAY();
+		break;
+    }
+	return 0;
 }
 
-static unsigned int ui_displayReleaseHeight_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	cx_sha256_t hash;
-	unsigned char hash_buffer[32];
-		// use the G_io_apdu buffer as a scratchpad to minimize stack usage
-	uint8_t * address_with_check = G_io_apdu_buffer;
+static const bagl_element_t ui_displayRecipient[] = {
+	UI_BACKGROUND(),
+	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the recipient
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
+};
 
+static unsigned int ui_displayRecipient_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
 	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &load_amount,
+            &load_release_height
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &load_amount,
+            &load_release_height
+        );
 		UX_REDISPLAY();
 		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-	    for(uint8_t i=0; i<2; i++){
-			// display recipient address on screen
-			memmove(address_with_check, CTX.address, 34);
-
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
-			cx_sha256_init(&hash);
-			cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
-			memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-			size_t output_len;
-			btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-			CTX.fullStr[output_len] = '\0';
-			CTX.fullStr_len = output_len;
-			memmove(CTX.partialStr, CTX.fullStr, 12);
-			CTX.partialStr[12] = '\0';
-			CTX.displayIndex = 0;
-
-			UX_DISPLAY(ui_displayUnstakeAddress, ui_prepro_displayUnstakeAddress);
-		}
-		break;
-	}
+    }
 	return 0;
 }
 
@@ -238,88 +190,169 @@ static const bagl_element_t ui_displayAmount[] = {
 	UI_BACKGROUND(),
 	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
 	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
-#ifdef HELIUM_TESTNET
-	UI_TEXT(0x00, 0, 12, 128, "Unstake TNT"),
-#else
-	UI_TEXT(0x00, 0, 12, 128, "Unstake HNT"),
-#endif
+	UI_TEXT(0x00, 0, 12, 128, global.title),
 	// The visible portion of the amount
-	UI_TEXT(0x00, 0, 26, 128, CTX.partialStr),
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
 };
 
-static const bagl_element_t* ui_prepro_displayAmount(const bagl_element_t *element) {
-	int fullSize = CTX.fullStr_len;
-	if ((element->component.userid == 1 && CTX.displayIndex == 0) ||
-	    (element->component.userid == 2 && CTX.displayIndex == fullSize-12)) {
-		return NULL;
-	}
-	return element;
-}
-
-static unsigned int ui_displayAmount_button(unsigned int button_mask,  __attribute__((unused)) unsigned int button_mask_counter) {
-	int fullSize = CTX.fullStr_len;
-	uint8_t len;
-
-	switch (button_mask) {
-	case BUTTON_LEFT:
-	case BUTTON_EVT_FAST | BUTTON_LEFT: // SEEK LEFT
-		if (CTX.displayIndex > 0) {
-			CTX.displayIndex--;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
+static unsigned int ui_displayAmount_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+    switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        change_page(
+            PREV,
+            &local_load_wallet,
+            &load_recipient
+        );
+        UX_REDISPLAY();
 		break;
-
-	case BUTTON_RIGHT:
-	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		if (CTX.displayIndex < fullSize-12) {
-			CTX.displayIndex++;
-		}
-		memmove(CTX.partialStr, CTX.fullStr+CTX.displayIndex, 12);
-		UX_REDISPLAY();
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        change_page(
+            NEXT,
+            &local_load_wallet,
+            &load_recipient
+        );
+        UX_REDISPLAY();
 		break;
-
-	case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-
-        // display release height of funds
-		len = bin2dec(CTX.fullStr, CTX.stake_release_height);
-		CTX.fullStr_len = len;
-		CTX.fullStr[len] = '\0';
-
-		uint8_t partlen = 12;
-		if(len < 12){
-			partlen = len;
-		}
-		memmove(CTX.partialStr, CTX.fullStr, partlen);
-		CTX.partialStr[partlen] = '\0';
-		CTX.displayIndex = 0;
-
-		UX_DISPLAY(ui_displayReleaseHeight, ui_prepro_displayReleaseHeight);
-
-		break;
-	}
+    }
 	return 0;
 }
 
-void handle_unstake_validator_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags, __attribute__((unused)) volatile unsigned int *tx) {
-    if(save_unstake_validator_context(p1,p2,dataBuffer, dataLength, &CTX)) {
-        // display amount on screen
-        uint8_t len = pretty_print_hnt(CTX.fullStr, CTX.stake_amount);
-        uint8_t i = 0;
-        while(CTX.fullStr[i] != '\0' && i<12){
-            CTX.partialStr[i] = CTX.fullStr[i];
-            i++;
+static const bagl_element_t ui_getPublicKey[] = {
+	UI_BACKGROUND(),
+	UI_ICON_LEFT(0x01, BAGL_GLYPH_ICON_LEFT),
+	UI_ICON_RIGHT(0x02, BAGL_GLYPH_ICON_RIGHT),
+	UI_TEXT(0x00, 0, 12, 128, global.title),
+	// The visible portion of the public key or address.
+	UI_TEXT(0x00, 0, 26, 128, global.partialStr),
+};
+
+// Define the button handler for the comparison screen. Again, this is nearly
+// identical to the signHash comparison button handler.
+static unsigned int ui_getPublicKey_button(unsigned int button_mask, __attribute__((unused)) unsigned int button_mask_counter) {
+	switch (button_mask) {
+	case BUTTON_LEFT | BUTTON_EVT_RELEASED: // SEEK LEFT
+        if (!global.lock) {
+            change_page(
+                PREV,
+                &load_deny,
+                &load_amount
+            );
         }
-        CTX.partialStr[i] = '\0';
-        CTX.fullStr_len = len;
+		UX_REDISPLAY();
+		break;
+	case BUTTON_RIGHT | BUTTON_EVT_RELEASED: // SEEK RIGHT
+        if (!global.lock) {
+            change_page(
+                NEXT,
+                &load_deny,
+                &load_amount
+            );
+        }
+		UX_REDISPLAY();
+		break;
+    }
+	return 0;
+}
 
-        CTX.displayIndex = 0;
+static void local_load_wallet(page_cmd_t page_cmd) {
+    load_wallet(page_cmd, load_deny, load_amount);
+    UX_DISPLAY(ui_getPublicKey, NULL);
+}
 
-        UX_DISPLAY(ui_displayAmount, ui_prepro_displayAmount);
-        *flags |= IO_ASYNCH_REPLY;
+void handle_unstake_validator_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength,
+                             volatile unsigned int *flags, __attribute__((unused)) volatile unsigned int *tx) {
+
+    if(save_unstake_validator_context(p1, p2, dataBuffer, dataLength, &CTX)) {
+        local_load_wallet(FIRST);
     } else {
         display_error();
     }
+	*flags |= IO_ASYNCH_REPLY;
+}
+
+static void load_fee(page_cmd_t page_cmd) {
+    uint8_t len = bin2dec(global.fullStr, CTX.fee);
+    global.title_len = sizeof("DC Fee (1/n)");
+    memcpy(global.title, &"DC Fee (1/n)", global.title_len);
+    global.fullStr_len = len;
+    global.fullStr[len] = '\0';
+    global.displayIndex = 0;
+    change_page(
+        page_cmd,
+        &load_release_height,
+        &load_signature
+    );
+    UX_DISPLAY(ui_displayFee, NULL);
+}
+
+static void load_recipient(page_cmd_t page_cmd) {
+	cx_sha256_t hash;
+	unsigned char hash_buffer[32];
+	// use the G_io_apdu buffer as a scratchpad to minimize stack usage
+	uint8_t * address_with_check = G_io_apdu_buffer;
+    global.title_len = sizeof("Validator Addr (1/n)");
+    memcpy(global.title, &"Validator Addr (1/n)", global.title_len);
+    for(uint8_t i=0; i<2; i++){
+        memmove(address_with_check, CTX.address, 34);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, address_with_check, 34, hash_buffer, 32);
+        cx_sha256_init(&hash);
+        cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
+        memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
+        size_t output_len;
+        btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+        global.fullStr[output_len] = '\0';
+        global.fullStr_len = output_len;
+        change_page(
+            page_cmd,
+            &load_amount,
+            &load_release_height
+        );
+    }
+    UX_DISPLAY(ui_displayRecipient, NULL);
+}
+
+static void load_release_height(page_cmd_t page_cmd){
+    uint8_t len;
+    global.title_len = sizeof("Release Height (1/n)");
+    memcpy(global.title, &"Release Height (1/n)", global.title_len);
+    len = bin2dec(global.fullStr, CTX.stake_release_height);
+    global.fullStr_len = len;
+    global.fullStr[len] = '\0';
+
+    change_page(
+        page_cmd,
+        &load_recipient,
+        &load_fee
+    );
+    UX_DISPLAY(ui_displayReleaseHeight, NULL);
+}
+
+static void load_amount(page_cmd_t page_cmd){
+    #ifdef HELIUM_TESTNET
+    global.title_len = sizeof("Unstake TNT (1/n)");
+    memcpy(global.title, &"Unstake TNT (1/n)", global.title_len);
+    #else
+    global.title_len = sizeof("Unstake HNT (1/n)");
+    memcpy(global.title, &"Unstake HNT (1/n)", global.title_len);
+    #endif
+    // display amount on screen
+    uint8_t len = pretty_print_hnt(global.fullStr, CTX.stake_amount);
+    global.fullStr_len = len;
+    change_page(
+        page_cmd,
+        &load_signature,
+        &load_recipient
+    );
+    UX_DISPLAY(ui_displayAmount, NULL);
+}
+
+static void load_signature(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_approve, NULL);
+}
+
+static void load_deny(__attribute__((unused)) page_cmd_t page_cmd) {
+    UX_DISPLAY(ui_signTxn_deny, NULL);
 }
 
 #endif

--- a/src/ux/nanox/nanox_burn_txn.c
+++ b/src/ux/nanox/nanox_burn_txn.c
@@ -13,14 +13,14 @@
 #include "save_context.h"
 #include "nanox_error.h"
 
-#define CTX global.burnContext
+#define CTX cmd.burnContext
 
 static void init_amount(void)
 {
   uint8_t len;
 
-  len = pretty_print_hnt(CTX.fullStr, CTX.amount);
-  CTX.fullStr_len = len;
+  len = pretty_print_hnt(global.fullStr, CTX.amount);
+  global.fullStr_len = len;
 }
 
 static void init_recipient(void)
@@ -40,9 +40,9 @@ static void init_recipient(void)
     cx_sha256_init(&hash);
     cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
     memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-    btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-    CTX.fullStr[output_len] = '\0';
-    CTX.fullStr_len = output_len;
+    btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+    global.fullStr[output_len] = '\0';
+    global.fullStr_len = output_len;
     /* UX_DISPLAY(ui_displayRecipient, ui_prepro_displayRecipient); */
   }
 }
@@ -52,9 +52,9 @@ static void init_memo(void)
   uint8_t len;
 
   // display memo
-  len = u64_to_base64(CTX.fullStr, CTX.memo);
-  CTX.fullStr_len = len;
-  CTX.fullStr[len] = '\0';
+  len = u64_to_base64(global.fullStr, CTX.memo);
+  global.fullStr_len = len;
+  global.fullStr[len] = '\0';
 }
 
 static void init_fee(void)
@@ -62,9 +62,9 @@ static void init_fee(void)
   uint8_t len;
 
   // display data credit transaction fee
-  len = bin2dec(CTX.fullStr, CTX.fee);
-  CTX.fullStr_len = len;
-  CTX.fullStr[len] = '\0';
+  len = bin2dec(global.fullStr, CTX.fee);
+  global.fullStr_len = len;
+  global.fullStr[len] = '\0';
 
 }
 
@@ -73,7 +73,7 @@ static void validate_transaction(bool isApproved)
   int adpu_tx;
 
   if (isApproved) {
-    adpu_tx = create_helium_burn_txn(CTX.account_index);
+    adpu_tx = create_helium_burn_txn(global.account_index);
     io_exchange_with_code(SW_OK, adpu_tx);
   }
   else {

--- a/src/ux/nanox/nanox_burn_txn.c
+++ b/src/ux/nanox/nanox_burn_txn.c
@@ -12,6 +12,7 @@
 #include "helium_ux.h"
 #include "save_context.h"
 #include "nanox_error.h"
+#include "nanox_wallet.h"
 
 #define CTX cmd.burnContext
 
@@ -88,6 +89,15 @@ static void validate_transaction(bool isApproved)
 }
 
 UX_STEP_NOCB_INIT(
+    ux_burn_display_wallet,
+    bnnn_paging,
+    init_wallet(),
+    {
+      .title = (char *)global.title,
+      .text = (char *)global.fullStr
+    });
+
+UX_STEP_NOCB_INIT(
     ux_burn_display_amount,
     bnnn_paging,
     init_amount(),
@@ -147,7 +157,7 @@ UX_STEP_CB(
 
 
 UX_DEF(ux_burn_sign_transaction_flow,
-       &ux_burn_display_amount,
+       &ux_burn_display_wallet,
        &ux_burn_display_recipient_address,
        &ux_burn_display_memo,
        &ux_burn_display_fee,

--- a/src/ux/nanox/nanox_burn_txn.c
+++ b/src/ux/nanox/nanox_burn_txn.c
@@ -97,7 +97,7 @@ UX_STEP_NOCB_INIT(
 #else
       .title = "Burn HNT",
 #endif
-	.text = (char *)global.burnContext.fullStr
+	.text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -106,7 +106,7 @@ UX_STEP_NOCB_INIT(
     init_recipient(),
     {
       .title = "Recipient Address",
-      .text = (char *)global.burnContext.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -115,7 +115,7 @@ UX_STEP_NOCB_INIT(
     init_fee(),
     {
       .title = "Data Credit Fee",
-      .text = (char *)global.burnContext.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -124,7 +124,7 @@ UX_STEP_NOCB_INIT(
     init_memo(),
     {
       .title = "Burn Memo",
-      .text = (char *)global.burnContext.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_CB(

--- a/src/ux/nanox/nanox_get_public_key.c
+++ b/src/ux/nanox/nanox_get_public_key.c
@@ -11,12 +11,21 @@
 
 #define CTX cmd.getPublicKeyContext
 
+static uint16_t adpu_tx;
+
+static void flush_key()
+{
+  io_exchange_with_code(SW_OK, adpu_tx);
+  ui_idle();
+}
+
+
 UX_FLOW_DEF_VALID(
     ux_display_public_flow_1_step, 
     bnnn_paging,
-    ui_idle(),
+    flush_key(),
     {
-      .title = "Confirm Address",
+      .title = (char *)global.title,
       .text = (char *)global.fullStr
     });
 
@@ -42,11 +51,11 @@ void handle_get_public_key(uint8_t p1, uint8_t p2,
                            __attribute__((unused)) volatile unsigned int *flags,
                            __attribute__((unused)) volatile unsigned int *tx) {
 	size_t output_len;
+    adpu_tx = 2;
 	// Sanity-check the command parameters.
 	if ((p1 != P1_PUBKEY_DISPLAY_ON) && (p1 != P1_PUBKEY_DISPLAY_OFF)) {
 		THROW(SW_INVALID_PARAM);
 	}
-	uint16_t adpu_tx = 2;
 
 	G_io_apdu_buffer[0] = 0; // prepend 0 byte to signify b58 format
 #ifdef HELIUM_TESTNET
@@ -54,12 +63,31 @@ void handle_get_public_key(uint8_t p1, uint8_t p2,
 #else
 	G_io_apdu_buffer[1] = NETTYPE_MAIN | KEYTYPE_ED25519;
 #endif
-	uint8_t account = p2;
-	get_pubkey_bytes(account, &G_io_apdu_buffer[adpu_tx]);
+	global.account_index = p2;
+	get_pubkey_bytes(global.account_index, &G_io_apdu_buffer[adpu_tx]);
 	adpu_tx += SIZE_OF_PUB_KEY_BIN;
 
 	cx_sha256_t hash;
 	unsigned char hash_buffer[32];
+
+    for(uint8_t i=0; i<2; i++) {
+        if (global.account_index < 10) {
+            global.title_len = sizeof("Confirm Wallet N\0");
+            memcpy(global.title, &"Confirm Wallet N\0", global.title_len);
+            global.title[global.title_len - 3] = global.account_index + 48;
+        } else if (global.account_index < 100) {
+            global.title_len = sizeof("Confirm Wallet NN\0");
+            memcpy(global.title, &"Confirm Wallet NN\0", global.title_len);
+            global.title[global.title_len - 4] = global.account_index/10 + 48;
+            global.title[global.title_len - 3] = global.account_index%10 + 48;
+        } else {
+            global.title_len = sizeof("Confirm Wallet NNN\0");
+            memcpy(global.title, &"Confirm Wallet NNN\0", global.title_len);
+            global.title[global.title_len - 5] = global.account_index/100 + 48;
+            global.title[global.title_len - 4] = global.account_index%100/10 + 48;
+            global.title[global.title_len - 3] = global.account_index%10 + 48;
+        }
+    }
 
 	if (p1 == P1_PUBKEY_DISPLAY_ON) {
 	  cx_sha256_init(&hash);
@@ -72,17 +100,17 @@ void handle_get_public_key(uint8_t p1, uint8_t p2,
 
 	  // Encoding key as a base58 string
 	  btchip_encode_base58(G_io_apdu_buffer, adpu_tx, global.fullStr, &output_len);
+      btchip_encode_base58(G_io_apdu_buffer, adpu_tx, global.fullStr, &output_len);
 	  global.fullStr[51] = '\0';
 
 	  // Running the flow showing the pubkey in the screen
 	  ui_getPublicKey();
 
-	
 	  *flags |= IO_ASYNCH_REPLY;
-	}
-
-	// Flush the APDU buffer, sending the response.
-	io_exchange_with_code(SW_OK, adpu_tx);
+	} else {
+        // Flush the APDU buffer, sending the response.
+	    io_exchange_with_code(SW_OK, adpu_tx);
+    }
 }
 
 #endif

--- a/src/ux/nanox/nanox_get_public_key.c
+++ b/src/ux/nanox/nanox_get_public_key.c
@@ -17,7 +17,7 @@ UX_FLOW_DEF_VALID(
     ui_idle(),
     {
       .title = "Confirm Address",
-      .text = (char *)global.getPublicKeyContext.fullStr
+      .text = (char *)global.fullStr
     });
 
 

--- a/src/ux/nanox/nanox_get_public_key.c
+++ b/src/ux/nanox/nanox_get_public_key.c
@@ -9,7 +9,7 @@
 #include "helium_ux.h"
 #include "nanox_error.h"
 
-#define CTX global.getPublicKeyContext
+#define CTX cmd.getPublicKeyContext
 
 UX_FLOW_DEF_VALID(
     ux_display_public_flow_1_step, 
@@ -71,8 +71,8 @@ void handle_get_public_key(uint8_t p1, uint8_t p2,
 	  adpu_tx += SIZE_OF_SHA_CHECKSUM;
 
 	  // Encoding key as a base58 string
-	  btchip_encode_base58(G_io_apdu_buffer, adpu_tx, CTX.fullStr, &output_len);
-	  CTX.fullStr[51] = '\0';
+	  btchip_encode_base58(G_io_apdu_buffer, adpu_tx, global.fullStr, &output_len);
+	  global.fullStr[51] = '\0';
 
 	  // Running the flow showing the pubkey in the screen
 	  ui_getPublicKey();

--- a/src/ux/nanox/nanox_payment_txn.c
+++ b/src/ux/nanox/nanox_payment_txn.c
@@ -12,6 +12,7 @@
 #include "helium_ux.h"
 #include "save_context.h"
 #include "nanox_error.h"
+#include "nanox_wallet.h"
 
 #define CTX cmd.paymentContext
 
@@ -67,7 +68,6 @@ static void init_memo(void)
   global.fullStr[len] = '\0';
 }
 
-
 static void validate_transaction(bool isApproved)
 {
   int adpu_tx;
@@ -82,10 +82,18 @@ static void validate_transaction(bool isApproved)
     // send a single 0 byte to differentiate from app not running
     io_exchange_with_code(SW_OK, 1);
   }
-
   // Go back to main menu
   ui_idle();
 }
+
+UX_STEP_NOCB_INIT(
+    ux_payment_display_wallet,
+    bnnn_paging,
+    init_wallet(),
+    {
+      .title = (char *)global.title,
+      .text = (char *)global.fullStr
+    });
 
 UX_STEP_NOCB_INIT(
     ux_payment_display_amount,
@@ -147,6 +155,7 @@ UX_STEP_CB(
 
 
 UX_DEF(ux_payment_sign_transaction_flow,
+       &ux_payment_display_wallet,
        &ux_payment_display_amount,
        &ux_payment_display_recipient_address,
        &ux_payment_display_burn,

--- a/src/ux/nanox/nanox_payment_txn.c
+++ b/src/ux/nanox/nanox_payment_txn.c
@@ -97,7 +97,7 @@ UX_STEP_NOCB_INIT(
 #else
       .title = "Amount HNT",
 #endif
-	.text = (char *)global.paymentContext.fullStr
+	.text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -106,7 +106,7 @@ UX_STEP_NOCB_INIT(
     init_recipient(),
     {
       .title = "Recipient Address",
-      .text = (char *)global.paymentContext.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -115,7 +115,7 @@ UX_STEP_NOCB_INIT(
     init_memo(),
     {
       .title = "Payment Memo",
-      .text = (char *)global.burnContext.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -124,7 +124,7 @@ UX_STEP_NOCB_INIT(
     init_fee(),
     {
       .title = "Data Credit Fee",
-      .text = (char *)global.paymentContext.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_CB(

--- a/src/ux/nanox/nanox_payment_txn.c
+++ b/src/ux/nanox/nanox_payment_txn.c
@@ -13,14 +13,14 @@
 #include "save_context.h"
 #include "nanox_error.h"
 
-#define CTX global.paymentContext
+#define CTX cmd.paymentContext
 
 static void init_amount(void)
 {
   uint8_t len;
 
-  len = pretty_print_hnt(CTX.fullStr, CTX.amount);
-  CTX.fullStr_len = len;
+  len = pretty_print_hnt(global.fullStr, CTX.amount);
+  global.fullStr_len = len;
 }
 
 static void init_recipient(void)
@@ -40,9 +40,9 @@ static void init_recipient(void)
     cx_sha256_init(&hash);
     cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
     memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-    btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-    CTX.fullStr[output_len] = '\0';
-    CTX.fullStr_len = output_len;
+    btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+    global.fullStr[output_len] = '\0';
+    global.fullStr_len = output_len;
     /* UX_DISPLAY(ui_displayRecipient, ui_prepro_displayRecipient); */
   }
 }
@@ -52,9 +52,9 @@ static void init_fee(void)
   uint8_t len;
 
   // display data credit transaction fee
-  len = bin2dec(CTX.fullStr, CTX.fee);
-  CTX.fullStr_len = len;
-  CTX.fullStr[len] = '\0';
+  len = bin2dec(global.fullStr, CTX.fee);
+  global.fullStr_len = len;
+  global.fullStr[len] = '\0';
 }
 
 static void init_memo(void)
@@ -62,9 +62,9 @@ static void init_memo(void)
   uint8_t len;
 
   // display memo
-  len = u64_to_base64(CTX.fullStr, CTX.memo);
-  CTX.fullStr_len = len;
-  CTX.fullStr[len] = '\0';
+  len = u64_to_base64(global.fullStr, CTX.memo);
+  global.fullStr_len = len;
+  global.fullStr[len] = '\0';
 }
 
 
@@ -73,7 +73,7 @@ static void validate_transaction(bool isApproved)
   int adpu_tx;
 
   if (isApproved) {
-    adpu_tx = create_helium_pay_txn(CTX.account_index);
+    adpu_tx = create_helium_pay_txn(global.account_index);
     io_exchange_with_code(SW_OK, adpu_tx);
   }
   else {

--- a/src/ux/nanox/nanox_transfer_sec.c
+++ b/src/ux/nanox/nanox_transfer_sec.c
@@ -12,6 +12,7 @@
 #include "helium_ux.h"
 #include "save_context.h"
 #include "nanox_error.h"
+#include "nanox_wallet.h"
 
 #define CTX cmd.transferSecContext
 
@@ -75,6 +76,15 @@ static void validate_transaction(bool isApproved)
 }
 
 UX_STEP_NOCB_INIT(
+    ux_txfer_sec_display_wallet,
+    bnnn_paging,
+    init_wallet(),
+    {
+      .title = (char *)global.title,
+      .text = (char *)global.fullStr
+    });
+
+UX_STEP_NOCB_INIT(
     ux_txfer_sec_display_amount,
     bnnn_paging,
     init_amount(),
@@ -125,6 +135,7 @@ UX_STEP_CB(
 
 
 UX_DEF(ux_txfer_sec_sign_transaction_flow,
+       &ux_txfer_sec_display_wallet,
        &ux_txfer_sec_display_amount,
        &ux_txfer_sec_display_recipient_address,
        &ux_txfer_sec_display_fee,

--- a/src/ux/nanox/nanox_transfer_sec.c
+++ b/src/ux/nanox/nanox_transfer_sec.c
@@ -13,14 +13,14 @@
 #include "save_context.h"
 #include "nanox_error.h"
 
-#define CTX global.transferSecContext
+#define CTX cmd.transferSecContext
 
 static void init_amount(void)
 {
   uint8_t len;
 
-  len = pretty_print_hnt(CTX.fullStr, CTX.amount);
-  CTX.fullStr_len = len;
+  len = pretty_print_hnt(global.fullStr, CTX.amount);
+  global.fullStr_len = len;
 }
 
 static void init_recipient(void)
@@ -40,9 +40,9 @@ static void init_recipient(void)
     cx_sha256_init(&hash);
     cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
     memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-    btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-    CTX.fullStr[output_len] = '\0';
-    CTX.fullStr_len = output_len;
+    btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+    global.fullStr[output_len] = '\0';
+    global.fullStr_len = output_len;
   }
 }
 
@@ -51,9 +51,9 @@ static void init_fee(void)
   uint8_t len;
 
   // display data credit transaction fee
-  len = bin2dec(CTX.fullStr, CTX.fee);
-  CTX.fullStr_len = len;
-  CTX.fullStr[len] = '\0';
+  len = bin2dec(global.fullStr, CTX.fee);
+  global.fullStr_len = len;
+  global.fullStr[len] = '\0';
 }
 
 static void validate_transaction(bool isApproved)
@@ -61,7 +61,7 @@ static void validate_transaction(bool isApproved)
   int adpu_tx;
 
   if (isApproved) {
-    adpu_tx = create_helium_transfer_sec(CTX.account_index);
+    adpu_tx = create_helium_transfer_sec(global.account_index);
     io_exchange_with_code(SW_OK, adpu_tx);
   }
   else {
@@ -84,7 +84,7 @@ UX_STEP_NOCB_INIT(
 #else
       .title = "Amount HST",
 #endif
-	.text = (char *)CTX.fullStr
+	.text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -93,7 +93,7 @@ UX_STEP_NOCB_INIT(
     init_recipient(),
     {
       .title = "Recipient Address",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -102,7 +102,7 @@ UX_STEP_NOCB_INIT(
     init_fee(),
     {
       .title = "Data Credit Fee",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_CB(

--- a/src/ux/nanox/nanox_validator_stake_txn.c
+++ b/src/ux/nanox/nanox_validator_stake_txn.c
@@ -12,14 +12,14 @@
 #include "save_context.h"
 #include "nanox_error.h"
 
-#define CTX global.stakeValidatorContext
+#define CTX cmd.stakeValidatorContext
 
 static void init_stake_amount(void)
 {
   uint8_t len;
 
-  len = pretty_print_hnt(CTX.fullStr, CTX.stake);
-  CTX.fullStr_len = len;
+  len = pretty_print_hnt(global.fullStr, CTX.stake);
+  global.fullStr_len = len;
 }
 
 static void init_stake_address(void)
@@ -39,9 +39,9 @@ static void init_stake_address(void)
     cx_sha256_init(&hash);
     cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
     memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-    btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-    CTX.fullStr[output_len] = '\0';
-    CTX.fullStr_len = output_len;
+    btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+    global.fullStr[output_len] = '\0';
+    global.fullStr_len = output_len;
     /* UX_DISPLAY(ui_displayRecipient, ui_prepro_displayRecipient); */
   }
 }
@@ -51,9 +51,9 @@ static void init_fee(void)
   uint8_t len;
 
   // display data credit transaction fee
-  len = bin2dec(CTX.fullStr, CTX.fee);
-  CTX.fullStr_len = len;
-  CTX.fullStr[len] = '\0';
+  len = bin2dec(global.fullStr, CTX.fee);
+  global.fullStr_len = len;
+  global.fullStr[len] = '\0';
 		
   /* UX_DISPLAY(ui_displayFee, ui_prepro_displayFee); */
   /* break; */
@@ -64,7 +64,7 @@ static void validate_transaction(bool isApproved)
   int adpu_tx;
 
   if (isApproved) {
-    adpu_tx = create_helium_stake_txn(CTX.account_index);
+    adpu_tx = create_helium_stake_txn(global.account_index);
     io_exchange_with_code(SW_OK, adpu_tx);
   }
   else {
@@ -88,7 +88,7 @@ UX_STEP_NOCB_INIT(
 #else
       .title = "Stake HNT",
 #endif
-	.text = (char *)CTX.fullStr
+	.text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -97,7 +97,7 @@ UX_STEP_NOCB_INIT(
     init_stake_address(),
     {
       .title = "Stake Address",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -106,7 +106,7 @@ UX_STEP_NOCB_INIT(
     init_fee(),
     {
       .title = "Data Credit Fee",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_CB(

--- a/src/ux/nanox/nanox_validator_stake_txn.c
+++ b/src/ux/nanox/nanox_validator_stake_txn.c
@@ -11,6 +11,7 @@
 #include "helium_ux.h"
 #include "save_context.h"
 #include "nanox_error.h"
+#include "nanox_wallet.h"
 
 #define CTX cmd.stakeValidatorContext
 
@@ -79,6 +80,15 @@ static void validate_transaction(bool isApproved)
 }
 
 UX_STEP_NOCB_INIT(
+    ux_display_stake_wallet,
+    bnnn_paging,
+    init_wallet(),
+    {
+      .title = (char *)global.title,
+      .text = (char *)global.fullStr
+    });
+
+UX_STEP_NOCB_INIT(
     ux_display_stake_amount,
     bnnn_paging,
     init_stake_amount(),
@@ -129,6 +139,7 @@ UX_STEP_CB(
 
 
 UX_DEF(ux_sign_transaction_flow,
+       &ux_display_stake_wallet,
        &ux_display_stake_amount,
        &ux_display_stake_address,
        &ux_display_stake_fee,

--- a/src/ux/nanox/nanox_validator_txfer_txn.c
+++ b/src/ux/nanox/nanox_validator_txfer_txn.c
@@ -12,22 +12,22 @@
 #include "save_context.h"
 #include "nanox_error.h"
 
-#define CTX global.transferValidatorContext
+#define CTX cmd.transferValidatorContext
 
 static void init_stake_amount(void)
 {
   uint8_t len;
 
-  len = pretty_print_hnt(CTX.fullStr, CTX.stake_amount);
-  CTX.fullStr_len = len;
+  len = pretty_print_hnt(global.fullStr, CTX.stake_amount);
+  global.fullStr_len = len;
 }
 
 static void init_payment_amount(void)
 {
   uint8_t len;
 
-  len = pretty_print_hnt(CTX.fullStr, CTX.payment_amount);
-  CTX.fullStr_len = len;
+  len = pretty_print_hnt(global.fullStr, CTX.payment_amount);
+  global.fullStr_len = len;
 }
 
 static void init_old_owner(void)
@@ -46,9 +46,9 @@ static void init_old_owner(void)
     cx_sha256_init(&hash);
     cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
     memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-    btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-    CTX.fullStr[output_len] = '\0';
-    CTX.fullStr_len = output_len;
+    btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+    global.fullStr[output_len] = '\0';
+    global.fullStr_len = output_len;
   }
 }
 
@@ -68,9 +68,9 @@ static void init_new_owner(void)
     cx_sha256_init(&hash);
     cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
     memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-    btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-    CTX.fullStr[output_len] = '\0';
-    CTX.fullStr_len = output_len;
+    btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+    global.fullStr[output_len] = '\0';
+    global.fullStr_len = output_len;
   }
 }
 
@@ -90,9 +90,9 @@ static void init_old_address(void)
     cx_sha256_init(&hash);
     cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
     memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-    btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-    CTX.fullStr[output_len] = '\0';
-    CTX.fullStr_len = output_len;
+    btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+    global.fullStr[output_len] = '\0';
+    global.fullStr_len = output_len;
   }
 }
 
@@ -112,18 +112,18 @@ static void init_new_address(void)
     cx_sha256_init(&hash);
     cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
     memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-    btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-    CTX.fullStr[output_len] = '\0';
-    CTX.fullStr_len = output_len;
+    btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+    global.fullStr[output_len] = '\0';
+    global.fullStr_len = output_len;
   }
 }
 
 static void init_fee(void)
 {
   uint8_t len;
-  len = bin2dec(CTX.fullStr, CTX.fee);
-  CTX.fullStr_len = len;
-  CTX.fullStr[len] = '\0';
+  len = bin2dec(global.fullStr, CTX.fee);
+  global.fullStr_len = len;
+  global.fullStr[len] = '\0';
 }
 
 static void validate_transaction(bool isApproved)
@@ -131,7 +131,7 @@ static void validate_transaction(bool isApproved)
   int adpu_tx;
 
   if (isApproved) {
-    adpu_tx = create_helium_transfer_validator_txn(CTX.account_index);
+    adpu_tx = create_helium_transfer_validator_txn(global.account_index);
     io_exchange_with_code(SW_OK, adpu_tx);
   }
   else {
@@ -155,7 +155,7 @@ UX_STEP_NOCB_INIT(
 #else
       .title = "Transfer HNT Stake",
 #endif
-	.text = (char *)CTX.fullStr
+	.text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -168,7 +168,7 @@ UX_STEP_NOCB_INIT(
 #else
       .title = "HNT Paid to Old Owner",
 #endif
-	.text = (char *)CTX.fullStr
+	.text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -177,7 +177,7 @@ UX_STEP_NOCB_INIT(
     init_old_owner(),
     {
       .title = "Old Owner",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -186,7 +186,7 @@ UX_STEP_NOCB_INIT(
     init_new_owner(),
     {
       .title = "New Owner",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -195,7 +195,7 @@ UX_STEP_NOCB_INIT(
     init_old_address(),
     {
       .title = "Old Address",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -204,7 +204,7 @@ UX_STEP_NOCB_INIT(
     init_new_address(),
     {
       .title = "New Address",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -213,7 +213,7 @@ UX_STEP_NOCB_INIT(
     init_fee(),
     {
       .title = "Data Credit Fee",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_CB(

--- a/src/ux/nanox/nanox_validator_txfer_txn.c
+++ b/src/ux/nanox/nanox_validator_txfer_txn.c
@@ -11,6 +11,7 @@
 #include "helium_ux.h"
 #include "save_context.h"
 #include "nanox_error.h"
+#include "nanox_wallet.h"
 
 #define CTX cmd.transferValidatorContext
 
@@ -146,6 +147,15 @@ static void validate_transaction(bool isApproved)
 }
 
 UX_STEP_NOCB_INIT(
+    ux_txfer_display_stake_wallet,
+    bnnn_paging,
+    init_wallet(),
+    {
+      .title = (char *)global.title,
+      .text = (char *)global.fullStr
+    });
+
+UX_STEP_NOCB_INIT(
     ux_txfer_display_stake_amount,
     bnnn_paging,
     init_stake_amount(),
@@ -236,6 +246,7 @@ UX_STEP_CB(
 
 
 UX_DEF(ux_txfer_sign_transaction_flow,
+       &ux_txfer_display_stake_wallet,
        &ux_txfer_display_stake_amount,
        &ux_txfer_display_payment_amount,
        &ux_txfer_display_old_owner,

--- a/src/ux/nanox/nanox_validator_unstake_txn.c
+++ b/src/ux/nanox/nanox_validator_unstake_txn.c
@@ -11,6 +11,7 @@
 #include "helium_ux.h"
 #include "save_context.h"
 #include "nanox_error.h"
+#include "nanox_wallet.h"
 
 #define CTX cmd.unstakeValidatorContext
 
@@ -84,6 +85,15 @@ static void validate_transaction(bool isApproved)
 }
 
 UX_STEP_NOCB_INIT(
+    ux_display_unstake_wallet,
+    bnnn_paging,
+    init_wallet(),
+    {
+      .title = (char *)global.title,
+      .text = (char *)global.fullStr
+    });
+
+UX_STEP_NOCB_INIT(
     ux_display_unstake_amount,
     bnnn_paging,
     init_stake_amount(),
@@ -143,6 +153,7 @@ UX_STEP_CB(
 
 
 UX_DEF(ux_sign_stake_transaction_flow,
+       &ux_display_unstake_wallet,
        &ux_display_unstake_amount,
        &ux_display_stake_release_height,
        &ux_display_unstake_address,

--- a/src/ux/nanox/nanox_validator_unstake_txn.c
+++ b/src/ux/nanox/nanox_validator_unstake_txn.c
@@ -12,23 +12,23 @@
 #include "save_context.h"
 #include "nanox_error.h"
 
-#define CTX global.unstakeValidatorContext
+#define CTX cmd.unstakeValidatorContext
 
 static void init_stake_amount(void)
 {
   uint8_t len;
 
-  len = pretty_print_hnt(CTX.fullStr, CTX.stake_amount);
-  CTX.fullStr_len = len;
+  len = pretty_print_hnt(global.fullStr, CTX.stake_amount);
+  global.fullStr_len = len;
 }
 
 static void init_stake_release_height(void)
 {
   uint8_t len;
   // release height of stake
-  len = bin2dec(CTX.fullStr, CTX.stake_release_height);
-  CTX.fullStr_len = len;
-  CTX.fullStr[len] = '\0';
+  len = bin2dec(global.fullStr, CTX.stake_release_height);
+  global.fullStr_len = len;
+  global.fullStr[len] = '\0';
 }
 
 static void init_stake_address(void)
@@ -48,9 +48,9 @@ static void init_stake_address(void)
     cx_sha256_init(&hash);
     cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
     memmove(&address_with_check[34], hash_buffer, SIZE_OF_SHA_CHECKSUM);
-    btchip_encode_base58(address_with_check, 38, CTX.fullStr, &output_len);
-    CTX.fullStr[output_len] = '\0';
-    CTX.fullStr_len = output_len;
+    btchip_encode_base58(address_with_check, 38, global.fullStr, &output_len);
+    global.fullStr[output_len] = '\0';
+    global.fullStr_len = output_len;
     /* UX_DISPLAY(ui_displayRecipient, ui_prepro_displayRecipient); */
   }
 }
@@ -59,9 +59,9 @@ static void init_fee(void)
 {
   uint8_t len;
   // display data credit transaction fee
-  len = bin2dec(CTX.fullStr, CTX.fee);
-  CTX.fullStr_len = len;
-  CTX.fullStr[len] = '\0';
+  len = bin2dec(global.fullStr, CTX.fee);
+  global.fullStr_len = len;
+  global.fullStr[len] = '\0';
 }
 
 static void validate_transaction(bool isApproved)
@@ -69,7 +69,7 @@ static void validate_transaction(bool isApproved)
   int adpu_tx;
 
   if (isApproved) {
-    adpu_tx = create_helium_unstake_txn(CTX.account_index);
+    adpu_tx = create_helium_unstake_txn(global.account_index);
     io_exchange_with_code(SW_OK, adpu_tx);
   }
   else {
@@ -93,7 +93,7 @@ UX_STEP_NOCB_INIT(
 #else
       .title = "Unstake HNT",
 #endif
-	.text = (char *)CTX.fullStr
+	.text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -102,7 +102,7 @@ UX_STEP_NOCB_INIT(
     init_stake_release_height(),
     {
       .title = "Stake Release Height",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -111,7 +111,7 @@ UX_STEP_NOCB_INIT(
     init_stake_address(),
     {
       .title = "Unstake Address",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_NOCB_INIT(
@@ -120,7 +120,7 @@ UX_STEP_NOCB_INIT(
     init_fee(),
     {
       .title = "Data Credit Fee",
-      .text = (char *)CTX.fullStr
+      .text = (char *)global.fullStr
     });
 
 UX_STEP_CB(

--- a/src/ux/nanox/nanox_wallet.c
+++ b/src/ux/nanox/nanox_wallet.c
@@ -1,0 +1,60 @@
+#include "nanox_wallet.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <os.h>
+#include <os_io_seproxyhal.h>
+#include <cx.h>
+#include "helium.h"
+#include "helium_ux.h"
+
+void init_wallet(void)
+{
+    uint8_t adpu_tx;
+    size_t output_len;
+    cx_sha256_t hash;
+    unsigned char hash_buffer[32];
+    adpu_tx = 2;
+
+    G_io_apdu_buffer[0] = 0; // prepend 0 byte to signify b58 format
+#ifdef HELIUM_TESTNET
+    G_io_apdu_buffer[1] = NETTYPE_TEST | KEYTYPE_ED25519;
+#else
+    G_io_apdu_buffer[1] = NETTYPE_MAIN | KEYTYPE_ED25519;
+#endif
+    get_pubkey_bytes(global.account_index, &G_io_apdu_buffer[adpu_tx]);
+    adpu_tx += SIZE_OF_PUB_KEY_BIN;
+
+    cx_sha256_init(&hash);
+    cx_hash(&hash.header, CX_LAST, G_io_apdu_buffer, adpu_tx, hash_buffer, 32);
+    cx_sha256_init(&hash);
+    cx_hash(&hash.header, CX_LAST, hash_buffer, 32, hash_buffer, 32);
+
+    memmove(&G_io_apdu_buffer[adpu_tx], hash_buffer, SIZE_OF_SHA_CHECKSUM);
+    adpu_tx += SIZE_OF_SHA_CHECKSUM;
+
+    // for some reason this needs to be done twice to work
+    btchip_encode_base58(G_io_apdu_buffer, adpu_tx, global.fullStr, &output_len);
+    btchip_encode_base58(G_io_apdu_buffer, adpu_tx, global.fullStr, &output_len);
+
+    global.fullStr[51] = '\0';
+    global.fullStr_len = output_len;
+    global.displayIndex = 0;
+
+    if (global.account_index < 10) {
+        global.title_len = sizeof("Wallet N\0");
+        memcpy(global.title, &"Wallet N\0", global.title_len);
+        global.title[7] = global.account_index + 48;
+    } else if (global.account_index < 100) {
+        global.title_len = sizeof("Wallet NN\0");
+        memcpy(global.title, &"Wallet NN\0", global.title_len);
+        global.title[7] = global.account_index/10 + 48;
+        global.title[8] = global.account_index%10 + 48;
+    } else {
+        global.title_len = sizeof("Wallet NNN\0");
+        memcpy(global.title, &"Wallet NNN\0", global.title_len);
+        global.title[7] = global.account_index/100 + 48;
+        global.title[8] = global.account_index%100/10 + 48;
+        global.title[9] = global.account_index%10 + 48;
+    }
+}

--- a/src/ux/nanox/nanox_wallet.h
+++ b/src/ux/nanox/nanox_wallet.h
@@ -1,0 +1,8 @@
+
+#ifndef HELIUM_LEDGER_APP_NANOX_WALLET_H
+#define HELIUM_LEDGER_APP_NANOX_WALLET_H
+
+void init_wallet(void);
+
+
+#endif //HELIUM_LEDGER_APP_NANOX_WALLET_H

--- a/tests/integration/src/main.rs
+++ b/tests/integration/src/main.rs
@@ -88,7 +88,7 @@ fn test_save_payment_context(
         "\
     assert(ctx.amount == {amount});\r\n\
     assert(ctx.fee == {fee});\r\n\
-    assert(ctx.account_index == {account_index});\r\n\
+    assert(global.account_index == {account_index});\r\n\
     assert(ctx.memo == {memo});\r\n\
     for(uint8_t i=0; i<34; i++) {{\r\n\
     \tassert(ctx.payee[i] == payee[i]);\r\n\
@@ -123,7 +123,7 @@ fn test_save_burn_context(
         "\
     assert(ctx.amount == {amount});\r\n\
     assert(ctx.fee == {fee});\r\n\
-    assert(ctx.account_index == {account_index});\r\n\
+    assert(global.account_index == {account_index});\r\n\
     assert(ctx.memo == {memo});\r\n\
     for(uint8_t i=0; i<34; i++) {{\r\n\
     \tassert(ctx.payee[i] == payee[i]);\r\n\
@@ -156,7 +156,7 @@ fn test_save_transfer_sec_context(
         "\
     assert(ctx.amount == {amount});\r\n\
     assert(ctx.fee == {fee});\r\n\
-    assert(ctx.account_index == {account_index});\r\n\
+    assert(global.account_index == {account_index});\r\n\
     for(uint8_t i=0; i<34; i++) {{\r\n\
     \tassert(ctx.payee[i] == payee[i]);\r\n\
     }}\r\n\
@@ -186,7 +186,7 @@ fn test_save_validator_stake_context(
         "\
     assert(ctx.stake == {stake});\r\n\
     assert(ctx.fee == {fee});\r\n\
-    assert(ctx.account_index == {account_index});\r\n\
+    assert(global.account_index == {account_index});\r\n\
     for(uint8_t i=0; i<34; i++) {{\r\n\
     \tassert(ctx.address[i] == address[i]);\r\n\
     }}\r\n\
@@ -228,7 +228,7 @@ fn test_save_validator_transfer_context(
     assert(ctx.stake_amount == {stake_amount});\r\n\
     assert(ctx.payment_amount == {payment_amount});\r\n\
     assert(ctx.fee == {fee});\r\n\
-    assert(ctx.account_index == {account_index});\r\n\
+    assert(global.account_index == {account_index});\r\n\
     for(uint8_t i=0; i<34; i++) {{\r\n\
     \tassert(ctx.new_owner[i] == new_owner[i]);\r\n\
     }}\r\n\
@@ -270,7 +270,7 @@ fn test_save_validator_unstake_context(
     assert(ctx.stake_amount == {stake_amount});\r\n\
     assert(ctx.stake_release_height == {stake_release_height});\r\n\
     assert(ctx.fee == {fee});\r\n\
-    assert(ctx.account_index == {account_index});\r\n\
+    assert(global.account_index == {account_index});\r\n\
     for(uint8_t i=0; i<34; i++) {{\r\n\
     \tassert(ctx.address[i] == address[i]);\r\n\
     }}\r\n\

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 
 add_compile_definitions(TEST)
 
-include_directories(../../src)
+include_directories(../../src ../../src/ux/nanos)
 
 add_executable(test_save_context test_save_context.c)
 

--- a/tests/unit/test_save_context.c
+++ b/tests/unit/test_save_context.c
@@ -8,7 +8,9 @@
 
 #include <cmocka.h>
 
-#include "../../src/save_context.h"
+#include "save_context.h"
+
+globalContext_t global;
 
 static void test_save_payment_context(void **state) {
     uint8_t payee[] = {0, 1, 149, 222, 195, 16, 5, 249, 3, 234, 179, 175, 194, 131, 71, 143, 176, 224, 107, 71, 55, 65,

--- a/tests/unit/test_save_context.c
+++ b/tests/unit/test_save_context.c
@@ -20,7 +20,7 @@ static void test_save_payment_context(void **state) {
     save_payment_context(3, 0, payment_buffer, 66, &ctx);
     assert(ctx.amount == 8765432);
     assert(ctx.fee == 35000);
-    assert(ctx.account_index == 3);
+    assert(global.account_index == 3);
     assert(ctx.memo == 1234);
     for (uint8_t i = 0; i < 34; i++) {
         assert(ctx.payee[i] == payee[i]);
@@ -37,7 +37,7 @@ static void test_save_burn_context(void **state) {
     save_burn_context(8, 0, burn_buffer, 66, &ctx);
     assert(ctx.amount == 9993121);
     assert(ctx.fee == 342443);
-    assert(ctx.account_index == 8);
+    assert(global.account_index == 8);
     assert(ctx.memo == 13234);
     for (uint8_t i = 0; i < 34; i++) {
         assert(ctx.payee[i] == payee[i]);
@@ -54,7 +54,7 @@ static void test_save_sec_transfer_context(void **state) {
     save_transfer_sec_context(8, 0, transfer_sec_buffer, 58, &ctx);
     assert(ctx.amount == 9219);
     assert(ctx.fee == 3424343);
-    assert(ctx.account_index == 8);
+    assert(global.account_index == 8);
     for (uint8_t i = 0; i < 34; i++) {
         assert(ctx.payee[i] == payee[i]);
     }
@@ -70,7 +70,7 @@ static void test_save_validator_stake_context(void **state) {
     save_stake_validator_context(8, 0, stake_validator_buffer, 50, &ctx);
     assert(ctx.stake == 9122219);
     assert(ctx.fee == 11234);
-    assert(ctx.account_index == 8);
+    assert(global.account_index == 8);
     for (uint8_t i = 0; i < 34; i++) {
         assert(ctx.address[i] == address[i]);
     }
@@ -86,7 +86,7 @@ static void test_save_validator_transfer_context(void **state) {
     assert(ctx.stake_amount == 9122219);
     assert(ctx.payment_amount == 11234);
     assert(ctx.fee == 9123219);
-    assert(ctx.account_index == 8);
+    assert(global.account_index == 8);
     for(uint8_t i=0; i<34; i++) {
         assert(ctx.new_owner[i] == new_owner[i]);
     }
@@ -113,7 +113,7 @@ static void test_save_validator_unstake_context(void **state) {
     assert(ctx.stake_amount == 912114299);
     assert(ctx.stake_release_height == 9103312219);
     assert(ctx.fee == 771234);
-    assert(ctx.account_index == 8);
+    assert(global.account_index == 8);
     for (uint8_t i = 0; i < 34; i++) {
         assert(ctx.address[i] == address[i]);
     }


### PR DESCRIPTION
Currently, this PR fixes the UX flow on Nano S in two ways:

- to make it consistent with Nano X and Nano S+, scrolling left and right is possible throughout the app and double click is only used at the end to approve a transaction
- to improve security, the active wallet is displayed as the first element of every transaction; this avoids compelling a user to sign a transaction with the wrong wallet

This second feature will be integrated into the Nano X and Nano S+ transactions before this draft PR is ready for review.